### PR TITLE
Fix: Add explicit lifetime markers to resource accessor methods

### DIFF
--- a/crates/generator/templates/lib.rs.tera
+++ b/crates/generator/templates/lib.rs.tera
@@ -52,7 +52,7 @@ impl {{ service_name | capitalize }}Provider {
 
 {% for resource in resources %}
     /// Get {{ resource.name }} resource handler
-    pub fn {{ resource.name }}(&self) -> resources::{{ resource.name | capitalize }} {
+    pub fn {{ resource.name }}(&self) -> resources::{{ resource.name | capitalize }}<'_> {
         resources::{{ resource.name | capitalize }}::new(self)
     }
 {% endfor %}


### PR DESCRIPTION
## Summary

Fixes lifetime elision warnings in generated provider code by adding explicit lifetime markers to resource accessor method return types.

## Problem

Generated providers compiled successfully but produced many confusing warnings:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/lib.rs:231:42
    |
231 |     pub fn bucket(&self) -> resources::Bucket {
    |                                          ^^^^^     -------------------- the same lifetime is hidden here
```

**Before this fix:**
- AWS S3 Provider: 147 warnings
- AWS DynamoDB Provider: 53 warnings

## Solution

Added explicit `<'_>` lifetime marker to resource accessor return types in the lib.rs template:

```rust
// Before
pub fn bucket(&self) -> resources::Bucket {

// After  
pub fn bucket(&self) -> resources::Bucket<'_> {
```

## Testing

Tested with production AWS Smithy models:

### AWS S3 (38 resources)
- **Before:** 147 warnings
- **After:** 109 warnings (-38 lifetime warnings)
- **Lifetime warnings:** 0 ✅

### AWS DynamoDB (15 resources)
- **Before:** 53 warnings
- **After:** 38 warnings (-15 lifetime warnings)  
- **Lifetime warnings:** 0 ✅

## Impact

- Cleaner build output for generated providers
- Eliminates all lifetime elision warnings
- More professional, production-ready generated code
- Easier to spot real issues in build output

## Related

Fixes #17

---

**Note:** Remaining warnings are unrelated:
- `unused import` (HashMap in skeleton code)
- `should have an upper camel case name` (snake_case resource names)
- `deprecated function` (aws_config::load_from_env)

These can be addressed in future PRs.