### PR TITLE
feat: Add automatic tag creation on release PR merge

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,54 @@
+name: Auto Tag on Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  tag-release:
+    # Only run if PR was merged and has the "release" label
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+          echo "✅ Created and pushed tag v${{ steps.version.outputs.version }}"
+
+      - name: Tag already exists
+        if: steps.check_tag.outputs.exists == 'true'
+        run: |
+          echo "⚠️  Tag v${{ steps.version.outputs.version }} already exists, skipping tag creation"


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically creates and pushes a git tag when a release PR is merged.

## How it works

1. **Trigger**: Runs when a PR with the `release` label is merged to `main`
2. **Extract Version**: Reads version from workspace `Cargo.toml`
3. **Check Duplicates**: Verifies tag doesn't already exist
4. **Create Tag**: Creates annotated tag (e.g., `v0.2.1`)
5. **Push Tag**: Pushes tag to origin
6. **Trigger Release**: Tag push automatically triggers the existing `release.yml` workflow

## Benefits

- ✅ Eliminates manual tag creation step after merging release PRs
- ✅ Ensures tags are created immediately after merge
- ✅ Prevents duplicate tags with existence check
- ✅ Maintains release automation consistency

## Workflow Details

- **File**: `.github/workflows/auto-tag.yml`
- **Permissions**: `contents: write` (for tag creation)
- **Runs on**: PR close events on `main` branch
- **Condition**: Only if PR is merged AND has "release" label

## Example Flow

```
1. Merge release PR #27 (labeled "release")
2. auto-tag.yml workflow triggers
3. Creates tag v0.2.1 from Cargo.toml
4. Pushes tag to GitHub
5. release.yml workflow triggers on tag push
6. Builds binaries and publishes to crates.io
```

## Testing

The workflow will be tested when this PR is merged (it won't trigger since it doesn't have the "release" label). The next release PR will be the first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)