### PR TITLE
chore: Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2025-10-29
+
+### Fixed
+
+- **Service Name Sanitization** (#29)
+  - Enhanced `infer_service_name()` to remove domain suffixes (`.k8s.io`, `.apiserver`, `.googleapis.com`, `.azure.com`)
+  - Removes spec file suffixes (`_openapi`, `-openapi`, `_discovery`, `-discovery`)
+  - Removes version suffixes (`__v1`, `-v1`)
+  - Added `sanitize_name()` function to convert invalid characters to valid Rust identifiers
+  - Converts dots to underscores
+  - Cleans up consecutive underscores
+  - Strips leading/trailing underscores
+  - Fixes K8s service names: `apis__internal` → `apis_internal`
+
+- **Resource Name Sanitization** (#29)
+  - Enhanced `extract_resource_from_path()` in OpenAPI parser to strip domain suffixes
+  - Removes `.k8s.io`, `.googleapis.com`, `.apiserver`, `.azure.com` from resource names
+  - Fixes K8s resource names: `Storage.k8s.io` → `Storage`, `Internal.apiserver.k8s.io` → `Internal`
+  - All generated resource names are now valid Rust identifiers
+
+- **Unified README Formatting** (#29)
+  - Fixed CRUD operation formatting in `unified_README.md.tera`
+  - Added proper spacing before operation brackets
+  - Changed: `**ResourceName**[CRUD]` → `**ResourceName** [CRUD]`
+  - Only shows brackets when operations exist
+  - Improved readability of generated documentation
+
 ## [0.2.1] - 2025-10-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -697,4 +697,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
 
 ---
 
-**Last Updated**: 2025-10-29 (v0.2.1 - Bug Fixes and Robustness Improvements)
+**Last Updated**: 2025-10-29 (v0.2.2 - Name Sanitization and Formatting Fixes)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/hemmer-io/hemmer-provider-generator"

--- a/README.md
+++ b/README.md
@@ -465,5 +465,5 @@ All 6 planned phases are complete:
 
 ---
 
-**Version**: 0.2.1
+**Version**: 0.2.2
 **Last Updated**: 2025-10-29

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,9 +17,9 @@ name = "hemmer-provider-generator"
 path = "src/main.rs"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.2.1", path = "../common" }
-hemmer-provider-generator-parser = { version = "0.2.1", path = "../parser" }
-hemmer-provider-generator-generator = { version = "0.2.1", path = "../generator" }
+hemmer-provider-generator-common = { version = "0.2.2", path = "../common" }
+hemmer-provider-generator-parser = { version = "0.2.2", path = "../parser" }
+hemmer-provider-generator-generator = { version = "0.2.2", path = "../generator" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 colored = { workspace = true }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -11,7 +11,7 @@ description = "Code generation engine for Hemmer infrastructure providers"
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.2.1", path = "../common" }
+hemmer-provider-generator-common = { version = "0.2.2", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tera = { workspace = true }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -11,7 +11,7 @@ description = "Multi-format parsers for cloud SDK specifications (Smithy, OpenAP
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.2.1", path = "../common" }
+hemmer-provider-generator-common = { version = "0.2.2", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Release v0.2.2

This patch release fixes service and resource name sanitization issues that created invalid Rust identifiers in generated providers.

## Changes

### Fixed

- **Service Name Sanitization** (#29)
  - Enhanced filename-based service name inference
  - Removes domain suffixes: `.k8s.io`, `.apiserver`, `.googleapis.com`, `.azure.com`
  - Removes spec suffixes: `_openapi`, `-openapi`, `_discovery`, `-discovery`  
  - Removes version suffixes: `__v1`, `-v1`
  - Converts dots to underscores, cleans up `__`, strips leading/trailing `_`
  - **Example**: `apis__internal.apiserver.k8s.io_openapi.json` → `apis_internal`

- **Resource Name Sanitization** (#29)
  - Strips domain suffixes from OpenAPI path-based resource names
  - **Example**: `Storage.k8s.io` → `Storage`, `Internal.apiserver.k8s.io` → `Internal`
  - All resource names are now valid Rust identifiers

- **Unified README Formatting** (#29)
  - Fixed CRUD operation spacing: `**Name**[CRUD]` → `**Name** [CRUD]`
  - Only shows brackets when operations exist
  - Improved documentation readability

## Impact

- ✅ K8s providers now have clean service/resource names
- ✅ All generated code compiles without errors
- ✅ Better readability in generated documentation
- ✅ Works across AWS, GCP, Azure, and Kubernetes providers

## Version Updates

- Workspace version: 0.2.1 → 0.2.2
- Updated CHANGELOG.md
- Updated README.md
- Updated CLAUDE.md

## Testing

All 57 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)