### PR TITLE
fix: Use PAT for auto-tag workflow to trigger release

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_TAG_PAT }}
 
       - name: Extract version from Cargo.toml
         id: version


### PR DESCRIPTION
## Summary

This PR fixes the auto-tag workflow so it properly triggers the release workflow when creating tags.

## Problem

GitHub Actions workflows triggered by the default `GITHUB_TOKEN` cannot trigger other workflows (by design, to prevent recursive workflow triggers). When the auto-tag workflow created tags using `GITHUB_TOKEN`, it didn't trigger the release workflow.

## Solution

Use a Personal Access Token (PAT) in the checkout action. When subsequent git operations use this token, the tag push will properly trigger the release workflow.

## Changes

Updated `.github/workflows/auto-tag.yml`:
- Added `token: ${{ secrets.AUTO_TAG_PAT }}` to the checkout action
- All git operations (including `git push`) will now use the PAT

## Setup Completed

The repository secret `AUTO_TAG_PAT` has been configured with a PAT that has:
- ✅ `repo` scope (full control of repositories)
- ✅ `workflow` scope (update GitHub Actions workflows)

## Testing

The next release PR with the `release` label will test this:
1. Merge release PR
2. Auto-tag workflow creates and pushes tag
3. Release workflow should trigger automatically ✅

## Impact

- Future releases will be fully automated
- No need to manually push tags after merging release PRs
- Complete end-to-end release automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)