### PR TITLE
chore(deps): Update prost ecosystem to 0.14/0.16

### DIFF
--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -17,9 +17,9 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 rustdoc-types = "0.56"
-prost = "0.13"
-prost-types = "0.13"
-prost-reflect = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+prost-reflect = "0.16"
 
 [dev-dependencies]
 mockall = { workspace = true }


### PR DESCRIPTION
## Summary

This PR updates all prost-related dependencies together to resolve version conflicts between the individual Dependabot PRs.

## Problem

The individual Dependabot PRs (#43, #44, #46) cannot be merged separately because they have circular dependencies:

- **PR #46** (prost-reflect 0.14 → 0.16) fails because it requires prost-types 0.14
- **PR #43** (prost-types 0.13 → 0.14) fails because it requires prost 0.14  
- **PR #44** (prost 0.13 → 0.14) is needed by both

The error:
```
error[E0308]: mismatched types
   --> crates/parser/src/protobuf/parser.rs:74:61
    |
 74 |         let pool = DescriptorPool::from_file_descriptor_set(file_descriptor_set)
    |                                                             ^^^^^^^^^^^^^^^^^^^ 
    |                                                             expected `FileDescriptorSet`, 
    |                                                             found `prost_types::FileDescriptorSet`
```

## Solution

Update all three dependencies together in a single PR:

```diff
-prost = "0.13"
-prost-types = "0.13"
-prost-reflect = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+prost-reflect = "0.16"
```

## Changes

- ✅ `prost`: 0.13 → 0.14
- ✅ `prost-types`: 0.13 → 0.14  
- ✅ `prost-reflect`: 0.14 → 0.16

## Testing

All tests pass successfully:

```bash
$ cargo test --workspace --all-features
   57 tests passed

$ cargo clippy --workspace --all-features --all-targets -- -D warnings
   No warnings
```

## Next Steps

After merging this PR:
1. Close Dependabot PRs #43, #44, #46 (superseded by this PR)
2. Dependabot will automatically recognize these dependencies are updated

## Related PRs

Supersedes:
- #43 - chore(deps): Update prost-types requirement from 0.13 to 0.14
- #44 - chore(deps): Update prost requirement from 0.13 to 0.14
- #46 - chore(deps): Update prost-reflect requirement from 0.14 to 0.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)