### PR TITLE
chore: Group prost ecosystem dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
     reviewers:
       - "hemmer-io/engineering"
     groups:
+      # Group prost ecosystem updates together (they must be updated in sync)
+      prost-ecosystem:
+        patterns:
+          - "prost*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       # Group patch updates together
       minor-and-patch:
         patterns:


### PR DESCRIPTION
## Summary

This PR updates the Dependabot configuration to group all prost-related dependencies together, preventing the version conflict issues we just experienced.

## Problem

We just encountered an issue where Dependabot created 3 separate PRs for the prost ecosystem:
- #43 - prost-types 0.13 → 0.14
- #44 - prost 0.13 → 0.14  
- #46 - prost-reflect 0.14 → 0.16

These PRs couldn't be merged individually because they have circular dependencies, causing CI failures with type mismatch errors. We had to create PR #48 to update them all together.

## Solution

Add a dedicated group for prost ecosystem dependencies:

```yaml
groups:
  # Group prost ecosystem updates together (they must be updated in sync)
  prost-ecosystem:
    patterns:
      - "prost*"
    update-types:
      - "major"
      - "minor"
      - "patch"
```

## How It Works

- Matches any dependency starting with `prost` (prost, prost-types, prost-reflect, etc.)
- Groups all update types (major, minor, patch)
- Takes precedence over the general `minor-and-patch` group
- Creates a single PR for the entire ecosystem

## Future Behavior

Instead of 3 separate PRs:
```
❌ PR #1: chore(deps): Update prost requirement from 0.14 to 0.15
❌ PR #2: chore(deps): Update prost-types requirement from 0.14 to 0.15
❌ PR #3: chore(deps): Update prost-reflect requirement from 0.16 to 0.17
```

Dependabot will create one combined PR:
```
✅ PR: chore(deps): Bump prost-ecosystem
   - Updates prost 0.14 → 0.15
   - Updates prost-types 0.14 → 0.15
   - Updates prost-reflect 0.16 → 0.17
```

## Benefits

✅ **No more CI failures** - All prost dependencies updated together  
✅ **Easier to review** - Single PR instead of 3  
✅ **Faster merging** - No dependency conflicts  
✅ **Less noise** - Fewer PRs to manage  

## Testing

The Dependabot configuration follows the [official grouping documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

## Related

- Inspired by: #48 (combined prost update)
- Prevents: Issues like #43, #44, #46 from happening again

🤖 Generated with [Claude Code](https://claude.com/claude-code)