### PR TITLE
chore: Bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-11-01
+
+### Fixed
+
+- **Generator Code Quality** (#51, #52)
+  - Fixed empty service names generating invalid Rust syntax (`pub mod ;`)
+  - Skip specs with empty/whitespace service names with clear warning
+  - Fixed duplicate dependencies in generated Cargo.toml
+  - Deduplicate services by name, merging resources from duplicate services
+  - Generic solution works for all providers (AWS, GCP, Azure, Kubernetes)
+
+### Added
+
+- **Template Filter System** (#52)
+  - New `sdk_dependency` Tera filter for generic SDK dependency generation
+  - Eliminates provider-specific conditional logic in templates
+  - Usage: `{{ provider | sdk_dependency(service_name=service.name) }}`
+  - Supports AWS (`aws-sdk-{service}`), GCP (`google-{service}`), Azure (`azure-{service}`)
+
+### Changed
+
+- **Service Deduplication** (#52)
+  - Services deduplicated in CLI before creating ProviderDefinition
+  - Resources merged when duplicate service names found
+  - Simplified generator and templates by removing duplicate logic
+  - Single source of truth for deduplication
+
 ## [0.3.1] - 2025-11-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -697,4 +697,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
 
 ---
 
-**Last Updated**: 2025-11-01 (v0.3.1 - Dependency Updates and Dependabot Configuration)
+**Last Updated**: 2025-11-01 (v0.3.2 - Bug Fixes for Invalid Generated Code)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/hemmer-io/hemmer-provider-generator"

--- a/README.md
+++ b/README.md
@@ -465,5 +465,5 @@ All 6 planned phases are complete:
 
 ---
 
-**Version**: 0.3.1
+**Version**: 0.3.2
 **Last Updated**: 2025-11-01

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,9 +17,9 @@ name = "hemmer-provider-generator"
 path = "src/main.rs"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.1", path = "../common" }
-hemmer-provider-generator-parser = { version = "0.3.1", path = "../parser" }
-hemmer-provider-generator-generator = { version = "0.3.1", path = "../generator" }
+hemmer-provider-generator-common = { version = "0.3.2", path = "../common" }
+hemmer-provider-generator-parser = { version = "0.3.2", path = "../parser" }
+hemmer-provider-generator-generator = { version = "0.3.2", path = "../generator" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 colored = { workspace = true }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -11,7 +11,7 @@ description = "Code generation engine for Hemmer infrastructure providers"
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.1", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.2", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tera = { workspace = true }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -11,7 +11,7 @@ description = "Multi-format parsers for cloud SDK specifications (Smithy, OpenAP
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.1", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.2", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

Patch release to fix critical bugs that produced invalid Rust code in generated providers.

## Changes

### Bug Fixes (#51, #52)

**1. Empty Service Names**
- Fixed empty service names generating invalid Rust syntax (`pub mod ;`)
- Added validation to skip specs with empty/whitespace service names
- Shows clear warning message when skipping

**2. Duplicate Dependencies**
- Fixed duplicate dependencies in generated Cargo.toml (e.g., `aws-sdk-kinesis` appearing 6 times)
- Implemented generic service deduplication in CLI before ProviderDefinition creation
- Merges resources from services with duplicate names
- Works for all providers: AWS, GCP, Azure, Kubernetes

### Template Improvements (#52)

**New `sdk_dependency` Filter**
- Added custom Tera filter for generic SDK dependency generation
- Eliminates provider-specific conditional logic in templates
- Usage: `{{ provider | sdk_dependency(service_name=service.name) }}`
- Supports AWS (`aws-sdk-{service}`), GCP (`google-{service}`), Azure (`azure-{service}`)

**Benefits:**
- Single iteration loop for all providers
- No provider-specific conditionals in template
- Easier to add new providers
- More maintainable code

## Version Updates
- Workspace version: 0.3.1 → 0.3.2
- All workspace crate dependencies updated to 0.3.2
- CHANGELOG.md updated with v0.3.2 release notes
- README.md and CLAUDE.md version footers updated

## Impact

These fixes make generated providers buildable:
- ✅ No more invalid Rust syntax from empty module names
- ✅ No more duplicate dependency errors in Cargo.toml
- ✅ Generic solution that works for all providers
- ✅ Cleaner, more maintainable templates

## Testing

- ✅ All 57 tests pass
- ✅ `cargo clippy` clean with no warnings
- ✅ `cargo fmt` clean
- ✅ Ready for K8s, GCP, and AWS provider generation

## Release Process

Once merged, the auto-tag workflow will:
1. Create git tag `v0.3.2`
2. Trigger release workflow to build binaries
3. Create GitHub release with all artifacts

## Related
- Fixes #51 - Generator v0.3.1 produces invalid Rust code
- PR #52 - Bug fixes implementation