### PR TITLE
fix: Use suffix for keywords in composite names instead of r# prefix

### DIFF
--- a/crates/generator/templates/unified_service.rs.tera
+++ b/crates/generator/templates/unified_service.rs.tera
@@ -24,8 +24,8 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
         desired_input: &ResourceInput,
     ) -> Result<ResourcePlan> {
         match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier }}" => {
-                self.plan_{{ resource.name | sanitize_identifier }}(current_state, desired_input).await
+{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
+                self.plan_{{ resource.name | sanitize_identifier_part }}(current_state, desired_input).await
             }
 {% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
                 "Unknown resource type: {}.{}",
@@ -42,8 +42,8 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
         input: ResourceInput,
     ) -> Result<ResourceOutput> {
         match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier }}" => {
-                self.create_{{ resource.name | sanitize_identifier }}(input).await
+{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
+                self.create_{{ resource.name | sanitize_identifier_part }}(input).await
             }
 {% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
                 "Unknown resource type: {}.{}",
@@ -60,8 +60,8 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
         id: &str,
     ) -> Result<ResourceOutput> {
         match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier }}" => {
-                self.read_{{ resource.name | sanitize_identifier }}(id).await
+{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
+                self.read_{{ resource.name | sanitize_identifier_part }}(id).await
             }
 {% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
                 "Unknown resource type: {}.{}",
@@ -79,8 +79,8 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
         input: ResourceInput,
     ) -> Result<ResourceOutput> {
         match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier }}" => {
-                self.update_{{ resource.name | sanitize_identifier }}(id, input).await
+{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
+                self.update_{{ resource.name | sanitize_identifier_part }}(id, input).await
             }
 {% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
                 "Unknown resource type: {}.{}",
@@ -97,8 +97,8 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
         id: &str,
     ) -> Result<()> {
         match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier }}" => {
-                self.delete_{{ resource.name | sanitize_identifier }}(id).await
+{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
+                self.delete_{{ resource.name | sanitize_identifier_part }}(id).await
             }
 {% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
                 "Unknown resource type: {}.{}",
@@ -118,7 +118,7 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
     // ------------------------------------------------------------------------
 
     /// Plan changes to a {{ resource.name }} resource
-    async fn plan_{{ resource.name | sanitize_identifier }}(
+    async fn plan_{{ resource.name | sanitize_identifier_part }}(
         &self,
         current_state: Option<&ResourceOutput>,
         desired_input: &ResourceInput,
@@ -134,7 +134,7 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
     }
 
     /// Create a new {{ resource.name }} resource
-    async fn create_{{ resource.name | sanitize_identifier }}(
+    async fn create_{{ resource.name | sanitize_identifier_part }}(
         &self,
         input: ResourceInput,
     ) -> Result<ResourceOutput> {
@@ -166,7 +166,7 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
 {% endif %}    }
 
     /// Read a {{ resource.name }} resource
-    async fn read_{{ resource.name | sanitize_identifier }}(
+    async fn read_{{ resource.name | sanitize_identifier_part }}(
         &self,
         id: &str,
     ) -> Result<ResourceOutput> {
@@ -190,7 +190,7 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
 {% endif %}    }
 
     /// Update a {{ resource.name }} resource
-    async fn update_{{ resource.name | sanitize_identifier }}(
+    async fn update_{{ resource.name | sanitize_identifier_part }}(
         &self,
         id: &str,
         input: ResourceInput,
@@ -223,7 +223,7 @@ impl<'a> {{ service.name | capitalize }}Service<'a> {
 {% endif %}    }
 
     /// Delete a {{ resource.name }} resource
-    async fn delete_{{ resource.name | sanitize_identifier }}(
+    async fn delete_{{ resource.name | sanitize_identifier_part }}(
         &self,
         id: &str,
     ) -> Result<()> {


### PR DESCRIPTION
Fixes #57

## Problem

After PR #56, two critical bugs were discovered:

1. **GCP managedkafka**: Function names like `plan_r#type()` are invalid Rust syntax
2. **AWS batch**: Variable name `type` still not escaped with r# prefix

## Root Cause

The `r#` prefix only works for complete identifiers, not parts of composite names. For example:
- ✅ Valid: `let r#type = ...` (standalone identifier)
- ❌ Invalid: `fn plan_r#type() { ... }` (part of function name)

## Solution

Implemented a two-strategy approach:

### 1. Created `sanitize_identifier_part()` function
- For composite identifiers (function names)
- Appends `_` suffix to keywords instead of r# prefix
- Example: `type` → `type_` (valid in `plan_type_()`)

### 2. Keep `sanitize_rust_identifier()` for standalone identifiers
- For variable names
- Uses r# prefix for keywords
- Example: `type` → `r#type` (valid as variable)

### 3. Added new Tera filter `sanitize_identifier_part`
- Applied to resource names in function definitions
- Generates: `plan_type_()` instead of invalid `plan_r#type()`

### 4. Updated templates
- Function names use `sanitize_identifier_part`
- Variable names use `sanitize_identifier`

## Examples Fixed

**GCP managedkafka service**:
```rust
// Before (invalid):
fn plan_r#type() { ... }

// After (valid):
fn plan_type_() { ... }
```

**AWS batch service**:
```rust
// Before (keyword not escaped):
let type = input.get_string("type")?;

// After (properly escaped):
let r#type = input.get_string("type")?;
```

**K8s rbac.authorization**:
```rust
// Before:
fn plan_rbac.authorization() { ... }

// After:
fn plan_rbac_authorization() { ... }
```

## Testing

- Added 5 new unit tests for `sanitize_identifier_part`
- All 69 tests passing:
  - 22 tests in common crate (including 5 new sanitization tests)
  - 32 tests in parser crate
  - 15+ tests in generator and integration tests
- Clippy passes with no warnings
- `cargo fmt` applied

## Changes

**crates/common/src/lib.rs**:
- Added `sanitize_identifier_part()` function with comprehensive docs
- Added 5 unit tests covering dots, keywords, special chars, edge cases

**crates/generator/src/templates.rs**:
- Registered `sanitize_identifier_part` filter
- Added filter implementation with detailed comments

**crates/generator/templates/unified_service.rs.tera**:
- Updated all function names to use `sanitize_identifier_part`
- Variable names continue to use `sanitize_identifier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>