### PR TITLE
chore: Bump version to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2025-11-03
+
+### Fixed
+
+- **Documentation Templates** (#64, #65)
+  - **#65**: Replaced Rust examples with KCL syntax in generated documentation
+    - Fixed `docs_getting_started.md.tera` to show KCL configuration examples instead of Rust async/await code
+    - Fixed `docs_service.md.tera` to use KCL resource creation patterns
+    - Removed Rust-specific sections (error handling, async operations, tokio runtime)
+    - Fixed CRUD bracket display to properly show `[CRUD]` indicators with closing brackets
+    - Fixed template syntax: replaced unsupported Python-style ternary expressions with proper Tera `{% if %}...{% else %}...{% endif %}` blocks
+    - Documentation now correctly targets Hemmer/KCL users instead of Rust developers
+
+### Impact
+
+Generated provider documentation now shows the correct user-facing language (KCL) instead of exposing internal Rust implementation details. This affects:
+- **Getting Started Guide**: Now shows KCL provider initialization and resource creation
+- **Service Documentation**: All examples use KCL syntax
+- **User Experience**: Documentation is now accessible to Hemmer users without Rust knowledge
+
 ## [0.3.3] - 2025-11-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/hemmer-io/hemmer-provider-generator"

--- a/README.md
+++ b/README.md
@@ -465,5 +465,5 @@ All 6 planned phases are complete:
 
 ---
 
-**Version**: 0.3.3
-**Last Updated**: 2025-11-02
+**Version**: 0.3.4
+**Last Updated**: 2025-11-03

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,9 +17,9 @@ name = "hemmer-provider-generator"
 path = "src/main.rs"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.3", path = "../common" }
-hemmer-provider-generator-parser = { version = "0.3.3", path = "../parser" }
-hemmer-provider-generator-generator = { version = "0.3.3", path = "../generator" }
+hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
+hemmer-provider-generator-parser = { version = "0.3.4", path = "../parser" }
+hemmer-provider-generator-generator = { version = "0.3.4", path = "../generator" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 colored = { workspace = true }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -11,7 +11,7 @@ description = "Code generation engine for Hemmer infrastructure providers"
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.3", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tera = { workspace = true }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -11,7 +11,7 @@ description = "Multi-format parsers for cloud SDK specifications (Smithy, OpenAP
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.3", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

Patch release v0.3.4 to include the documentation template fixes from PR #65.

## Changes

### Version Updates
- Workspace version: **0.3.3 → 0.3.4**
- All inter-crate dependencies updated to 0.3.4
- CHANGELOG.md updated with release notes
- README.md version and date updated

### What's in v0.3.4

**Fixed** (#64, #65):
- ✅ Replaced Rust examples with KCL syntax in generated documentation
- ✅ Fixed CRUD bracket display to properly show `[CRUD]` indicators
- ✅ Fixed template syntax: removed unsupported ternary expressions
- ✅ Documentation now targets Hemmer/KCL users instead of Rust developers

**Impact**:
Generated provider documentation now shows the correct user-facing language (KCL) instead of exposing internal Rust implementation details.

## Testing

✅ All 75 tests passing
✅ All crates compile successfully with new version numbers
✅ No clippy warnings

## Files Changed

- `Cargo.toml` - Workspace version
- `crates/*/Cargo.toml` - Inter-crate dependency versions (3 files)
- `CHANGELOG.md` - Added v0.3.4 section
- `README.md` - Updated version and date

## Release Process

Once merged:
1. Tag: `v0.3.4`
2. GitHub Release (automated via workflow)
3. No crates.io publish needed (installation script downloads from GitHub releases)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>