### PR TITLE
chore: Bump version to 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2025-11-03
+
+### Fixed
+
+- **AWS SDK Dependencies** (#67, #68)
+  - **#68**: Normalized AWS SDK dependency names to match actual crate names on crates.io
+    - Remove underscores from all AWS service names (e.g., `acm_pca` → `acmpca`, `route_53` → `route53`)
+    - Applied 5 special case mappings for non-standard crate names:
+      - `apigatewaymanagementapi` → `apigatewaymanagement` (remove extra "api" suffix)
+      - `configservice` → `config` (remove "service" suffix)
+      - `costandusagereportservice` → `costandusagereport` (remove "service" suffix)
+      - `lexmodels` → `lexmodelsv2` (add "v2" suffix)
+      - `pinpointsms` → `pinpointsmsvoice` (add "voice" suffix)
+    - Excluded 7 non-existent services (don't generate dependencies):
+      - `chimesdk`, `lexmodelbuildingservice`, `lexruntimeservice`, `databasemigrationservice`
+      - `elasticsearchservice`, `resourcegroupstaggingapi`, `marketplaceentitlementservice`
+    - Updated `unified_Cargo.toml.tera` to skip empty dependency names
+
+### Impact
+
+Generated AWS providers now build successfully with correct SDK dependencies:
+- **393 services** analyzed
+- **386 valid dependencies** generated (98.2% success rate)
+- **7 invalid services** excluded
+- **5 services** with special name mappings
+- All dependencies verified to exist on crates.io with stable versions (v1.0+)
+
 ## [0.3.4] - 2025-11-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/hemmer-io/hemmer-provider-generator"

--- a/README.md
+++ b/README.md
@@ -465,5 +465,5 @@ All 6 planned phases are complete:
 
 ---
 
-**Version**: 0.3.4
+**Version**: 0.3.5
 **Last Updated**: 2025-11-03

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,9 +17,9 @@ name = "hemmer-provider-generator"
 path = "src/main.rs"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
-hemmer-provider-generator-parser = { version = "0.3.4", path = "../parser" }
-hemmer-provider-generator-generator = { version = "0.3.4", path = "../generator" }
+hemmer-provider-generator-common = { version = "0.3.5", path = "../common" }
+hemmer-provider-generator-parser = { version = "0.3.5", path = "../parser" }
+hemmer-provider-generator-generator = { version = "0.3.5", path = "../generator" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 colored = { workspace = true }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -11,7 +11,7 @@ description = "Code generation engine for Hemmer infrastructure providers"
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.5", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tera = { workspace = true }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -11,7 +11,7 @@ description = "Multi-format parsers for cloud SDK specifications (Smithy, OpenAP
 readme = "README.md"
 
 [dependencies]
-hemmer-provider-generator-common = { version = "0.3.4", path = "../common" }
+hemmer-provider-generator-common = { version = "0.3.5", path = "../common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

Patch release v0.3.5 to include the AWS SDK dependency normalization fixes from PR #68.

## Changes

### Version Updates
- Workspace version: **0.3.4 → 0.3.5**
- All inter-crate dependencies updated to 0.3.5
- CHANGELOG.md updated with release notes
- README.md version updated

### What's in v0.3.5

**Fixed** (#67, #68):
- ✅ Normalized AWS SDK dependency names to match actual crate names on crates.io
- ✅ Remove underscores from all AWS service names (e.g., `acm_pca` → `acmpca`)
- ✅ Applied 5 special case mappings for non-standard names:
  - `apigatewaymanagementapi` → `apigatewaymanagement`
  - `configservice` → `config`
  - `costandusagereportservice` → `costandusagereport`
  - `lexmodels` → `lexmodelsv2`
  - `pinpointsms` → `pinpointsmsvoice`
- ✅ Excluded 7 non-existent services (chimesdk, lexmodelbuildingservice, etc.)
- ✅ Updated Cargo.toml template to skip empty dependencies

**Impact**:
Generated AWS providers now build successfully with correct SDK dependencies:
- **393 services** analyzed
- **386 valid dependencies** generated (98.2% success rate)
- **7 invalid services** excluded
- All dependencies verified to exist on crates.io with stable versions

## Testing

✅ All 75 tests passing
✅ All crates compile successfully with new version numbers
✅ No clippy warnings

## Files Changed

- `Cargo.toml` - Workspace version
- `crates/*/Cargo.toml` - Inter-crate dependency versions (3 files)
- `CHANGELOG.md` - Added v0.3.5 section
- `README.md` - Updated version

## Release Process

Once merged:
1. Tag: `v0.3.5`
2. GitHub Release (automated via workflow)
3. No crates.io publish needed (installation script downloads from GitHub releases)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>