### PR TITLE
chore: Ignore rustdoc-types 0.57 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
       include: "scope"
     reviewers:
       - "hemmer-io/engineering"
+    ignore:
+      # rustdoc-types version tracks rustdoc JSON format_version.
+      # Version 0.57 was published before any Rust compiler outputs format 57.
+      # Ignore until Rust nightly actually produces format_version 57.
+      - dependency-name: "rustdoc-types"
+        versions: ["0.57"]
     groups:
       # Group prost ecosystem updates together (they must be updated in sync)
       prost-ecosystem:


### PR DESCRIPTION
## Summary

- Adds dependabot ignore rule for rustdoc-types version 0.57
- Related to PR #70 which was closed because rustdoc-types 0.57 expects `format_version: 57` in JSON output, but the latest Rust nightly still produces `format_version: 56`

The rustdoc-types crate version tracks the rustdoc JSON format version. Version 0.57 was published to crates.io before any Rust compiler actually outputs format 57, making it unusable.

## Test plan

- [ ] Verify dependabot no longer opens PRs for rustdoc-types 0.57

🤖 Generated with [Claude Code](https://claude.com/claude-code)