### PR TITLE
feat: Refactor provider generation to use gRPC protocol and JCL manifests

### DIFF
--- a/crates/generator/templates/Cargo.toml.tera
+++ b/crates/generator/templates/Cargo.toml.tera
@@ -2,12 +2,21 @@
 name = "hemmer-{{ service_name }}-provider"
 version = "0.1.0"
 edition = "2021"
+description = "Hemmer provider for {{ service_name }}"
+
+[lib]
+name = "hemmer_{{ service_name }}_provider"
+path = "src/lib.rs"
+
+[[bin]]
+name = "hemmer-{{ service_name }}-provider"
+path = "src/main.rs"
 
 [dependencies]
-# Hemmer provider runtime (placeholder)
-# hemmer-runtime = "0.1"
+# Hemmer provider SDK
+hemmer-provider-sdk = "0.1"
 
-# SDK dependencies
+# Cloud SDK dependencies
 {% if provider == "Aws" %}aws-sdk-{{ service_name }} = "1"
 aws-config = "1"
 {% elif provider == "Gcp" %}# GCP SDK dependencies
@@ -16,10 +25,11 @@ aws-config = "1"
 
 # Standard dependencies
 anyhow = "1"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/generator/templates/lib.rs.tera
+++ b/crates/generator/templates/lib.rs.tera
@@ -4,7 +4,14 @@
 
 pub mod resources;
 
+use hemmer_provider_sdk::{
+    async_trait, serde_json, tonic,
+    ProviderService, ProviderSchema, Schema, Block, Attribute, AttributeType, AttributeFlags,
+    PlanResult, AttributeChange, ImportedResource, ProviderMetadata, ServerCapabilities,
+};
+use std::collections::HashMap;
 use thiserror::Error;
+use tracing::{debug, error, info};
 
 /// Provider error types
 #[derive(Error, Debug)]
@@ -18,6 +25,12 @@ pub enum ProviderError {
     #[error("Validation error: {0}")]
     ValidationError(String),
 
+    #[error("Configuration error: {0}")]
+    ConfigurationError(String),
+
+    #[error("Unknown resource type: {0}")]
+    UnknownResource(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -25,46 +38,291 @@ pub enum ProviderError {
 /// Result type for provider operations
 pub type Result<T> = std::result::Result<T, ProviderError>;
 
-/// Provider client
+/// {{ service_name | capitalize }} Provider
 pub struct {{ service_name | capitalize }}Provider {
 {% if provider == "Aws" %}
-    client: aws_sdk_{{ service_name }}::Client,
+    client: Option<aws_sdk_{{ service_name }}::Client>,
 {% elif provider == "Gcp" %}
-    // GCP client
+    // GCP client placeholder
+    _configured: bool,
 {% elif provider == "Azure" %}
-    // Azure client
+    // Azure client placeholder
+    _configured: bool,
+{% else %}
+    _configured: bool,
 {% endif %}
 }
 
 impl {{ service_name | capitalize }}Provider {
-    /// Create a new provider instance
-    pub async fn new() -> Result<Self> {
+    /// Create a new provider instance (unconfigured)
+    pub fn new() -> Self {
+        Self {
 {% if provider == "Aws" %}
-        let config = aws_config::load_from_env().await;
-        let client = aws_sdk_{{ service_name }}::Client::new(&config);
+            client: None,
+{% else %}
+            _configured: false,
 {% endif %}
-        Ok(Self {
+        }
+    }
+
+    /// Build the provider schema
+    fn build_schema() -> ProviderSchema {
+        let mut resources = HashMap::new();
+{% for resource in resources %}
+
+        // {{ resource.name | capitalize }} resource schema
+        let mut {{ resource.name }}_attrs = HashMap::new();
+{% for field in resource.fields %}
+        {{ resource.name }}_attrs.insert(
+            "{{ field.name }}".to_string(),
+            Attribute::new(
+                {{ field.field_type | sdk_attr_type }},
+{% if field.required %}
+                AttributeFlags::required(),
+{% else %}
+                AttributeFlags::optional(),
+{% endif %}
+            ){% if field.sensitive %}.sensitive(){% endif %}{% if field.description %}.with_description("{{ field.description }}"){% endif %}{% if field.immutable %}.with_force_new(){% endif %},
+        );
+{% endfor %}
+{% for output in resource.outputs %}
+        {{ resource.name }}_attrs.insert(
+            "{{ output.name }}".to_string(),
+            Attribute::new(
+                {{ output.field_type | sdk_attr_type }},
+                AttributeFlags::computed(),
+            ){% if output.description %}.with_description("{{ output.description }}"){% endif %},
+        );
+{% endfor %}
+        resources.insert(
+            "{{ resource.name }}".to_string(),
+            Schema {
+                version: 1,
+                block: Block {
+                    attributes: {{ resource.name }}_attrs,
+                    blocks: HashMap::new(),
+                },
+            },
+        );
+{% endfor %}
+
+        // Provider config schema
+        let mut config_attrs = HashMap::new();
 {% if provider == "Aws" %}
-            client,
+        config_attrs.insert(
+            "region".to_string(),
+            Attribute::optional_string().with_description("AWS region to use"),
+        );
+        config_attrs.insert(
+            "profile".to_string(),
+            Attribute::optional_string().with_description("AWS profile to use"),
+        );
+{% elif provider == "Gcp" %}
+        config_attrs.insert(
+            "project".to_string(),
+            Attribute::optional_string().with_description("GCP project ID"),
+        );
+        config_attrs.insert(
+            "region".to_string(),
+            Attribute::optional_string().with_description("GCP region to use"),
+        );
+{% elif provider == "Azure" %}
+        config_attrs.insert(
+            "subscription_id".to_string(),
+            Attribute::optional_string().with_description("Azure subscription ID"),
+        );
+        config_attrs.insert(
+            "tenant_id".to_string(),
+            Attribute::optional_string().with_description("Azure tenant ID"),
+        );
 {% endif %}
+
+        ProviderSchema {
+            provider: Schema {
+                version: 1,
+                block: Block {
+                    attributes: config_attrs,
+                    blocks: HashMap::new(),
+                },
+            },
+            resources,
+            data_sources: HashMap::new(),
+        }
+    }
+}
+
+impl Default for {{ service_name | capitalize }}Provider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProviderService for {{ service_name | capitalize }}Provider {
+    fn schema(&self) -> ProviderSchema {
+        Self::build_schema()
+    }
+
+    async fn configure(
+        &self,
+        config: serde_json::Value,
+    ) -> std::result::Result<Vec<tonic::Status>, tonic::Status> {
+        info!("Configuring {{ service_name }} provider");
+        debug!("Config: {:?}", config);
+
+{% if provider == "Aws" %}
+        // Load AWS config from environment, optionally using provided region/profile
+        let mut config_loader = aws_config::from_env();
+
+        if let Some(region) = config.get("region").and_then(|v| v.as_str()) {
+            config_loader = config_loader.region(aws_config::Region::new(region.to_string()));
+        }
+
+        if let Some(profile) = config.get("profile").and_then(|v| v.as_str()) {
+            config_loader = config_loader.profile_name(profile);
+        }
+
+        let sdk_config = config_loader.load().await;
+        let client = aws_sdk_{{ service_name }}::Client::new(&sdk_config);
+
+        // Store client (requires interior mutability in real implementation)
+        // For now, we'll reconstruct on each call
+        let _ = client;
+{% endif %}
+
+        Ok(vec![])
+    }
+
+    async fn plan(
+        &self,
+        resource_type: &str,
+        _prior_state: Option<serde_json::Value>,
+        proposed_state: serde_json::Value,
+        _config: serde_json::Value,
+    ) -> std::result::Result<PlanResult, tonic::Status> {
+        debug!("Planning {} resource", resource_type);
+
+        // For now, return the proposed state as the planned state
+        // Real implementation would diff prior vs proposed
+        Ok(PlanResult {
+            planned_state: proposed_state,
+            changes: vec![],
+            requires_replace: false,
         })
     }
 
+    async fn create(
+        &self,
+        resource_type: &str,
+        planned_state: serde_json::Value,
+        _config: serde_json::Value,
+    ) -> std::result::Result<serde_json::Value, tonic::Status> {
+        info!("Creating {} resource", resource_type);
+
+        match resource_type {
 {% for resource in resources %}
-    /// Get {{ resource.name }} resource handler
-    pub fn {{ resource.name }}(&self) -> resources::{{ resource.name | capitalize }}<'_> {
-        resources::{{ resource.name | capitalize }}::new(self)
-    }
+            "{{ resource.name }}" => {
+                // TODO: Implement {{ resource.name }} creation using SDK
+                debug!("Creating {{ resource.name }}: {:?}", planned_state);
+                Ok(planned_state)
+            }
 {% endfor %}
+            _ => {
+                error!("Unknown resource type: {}", resource_type);
+                Err(tonic::Status::not_found(format!(
+                    "Unknown resource type: {}",
+                    resource_type
+                )))
+            }
+        }
+    }
+
+    async fn read(
+        &self,
+        resource_type: &str,
+        current_state: serde_json::Value,
+        _config: serde_json::Value,
+    ) -> std::result::Result<serde_json::Value, tonic::Status> {
+        debug!("Reading {} resource", resource_type);
+
+        match resource_type {
+{% for resource in resources %}
+            "{{ resource.name }}" => {
+                // TODO: Implement {{ resource.name }} read using SDK
+                Ok(current_state)
+            }
+{% endfor %}
+            _ => Err(tonic::Status::not_found(format!(
+                "Unknown resource type: {}",
+                resource_type
+            ))),
+        }
+    }
+
+    async fn update(
+        &self,
+        resource_type: &str,
+        _prior_state: serde_json::Value,
+        planned_state: serde_json::Value,
+        _config: serde_json::Value,
+    ) -> std::result::Result<serde_json::Value, tonic::Status> {
+        info!("Updating {} resource", resource_type);
+
+        match resource_type {
+{% for resource in resources %}
+            "{{ resource.name }}" => {
+                // TODO: Implement {{ resource.name }} update using SDK
+                Ok(planned_state)
+            }
+{% endfor %}
+            _ => Err(tonic::Status::not_found(format!(
+                "Unknown resource type: {}",
+                resource_type
+            ))),
+        }
+    }
+
+    async fn delete(
+        &self,
+        resource_type: &str,
+        current_state: serde_json::Value,
+        _config: serde_json::Value,
+    ) -> std::result::Result<(), tonic::Status> {
+        info!("Deleting {} resource", resource_type);
+
+        match resource_type {
+{% for resource in resources %}
+            "{{ resource.name }}" => {
+                // TODO: Implement {{ resource.name }} deletion using SDK
+                debug!("Deleting {{ resource.name }}: {:?}", current_state);
+                Ok(())
+            }
+{% endfor %}
+            _ => Err(tonic::Status::not_found(format!(
+                "Unknown resource type: {}",
+                resource_type
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_provider_creation() {
-        // Provider creation test
-        // Note: This will fail without proper credentials
+    #[test]
+    fn test_provider_creation() {
+        let provider = {{ service_name | capitalize }}Provider::new();
+        let schema = provider.schema();
+        assert!(!schema.resources.is_empty());
+    }
+
+    #[test]
+    fn test_schema_has_resources() {
+        let provider = {{ service_name | capitalize }}Provider::new();
+        let schema = provider.schema();
+{% for resource in resources %}
+        assert!(schema.resources.contains_key("{{ resource.name }}"));
+{% endfor %}
     }
 }

--- a/crates/generator/templates/main.rs.tera
+++ b/crates/generator/templates/main.rs.tera
@@ -1,0 +1,20 @@
+//! {{ service_name | capitalize }} Provider - Entry Point
+//!
+//! Auto-generated from {{ provider }} SDK version {{ sdk_version }}
+
+use hemmer_provider_sdk::serve;
+
+// Import from the library crate
+use hemmer_{{ service_name }}_provider::{{ service_name | capitalize }}Provider;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
+    hemmer_provider_sdk::init_logging_with_default();
+
+    // Create and serve the provider
+    let provider = {{ service_name | capitalize }}Provider::new();
+    serve(provider).await?;
+
+    Ok(())
+}

--- a/crates/generator/templates/provider.jcf.tera
+++ b/crates/generator/templates/provider.jcf.tera
@@ -1,0 +1,95 @@
+# {{ service_name | capitalize }} Provider
+# Generated from {{ provider }} SDK version {{ sdk_version }}
+#
+# This provider implements CRUD operations for {{ service_name }} resources.
+
+provider = (
+    name: "{{ service_name }}",
+    version: "{{ sdk_version }}",
+    protocol: "grpc",
+
+    # Provider configuration schema
+    config: (
+{% if provider == "Aws" %}
+        region: (
+            type: "string",
+            optional: true,
+            description: "AWS region to use",
+        ),
+        profile: (
+            type: "string",
+            optional: true,
+            description: "AWS profile to use",
+        ),
+{% elif provider == "Gcp" %}
+        project: (
+            type: "string",
+            optional: true,
+            description: "GCP project ID",
+        ),
+        region: (
+            type: "string",
+            optional: true,
+            description: "GCP region to use",
+        ),
+{% elif provider == "Azure" %}
+        subscription_id: (
+            type: "string",
+            optional: true,
+            description: "Azure subscription ID",
+        ),
+        tenant_id: (
+            type: "string",
+            optional: true,
+            description: "Azure tenant ID",
+        ),
+{% endif %}
+    ),
+
+    # Resources
+    resources: (
+{% for resource in resources %}
+        {{ resource.name }}: (
+            description: "{{ resource.description | default(value=resource.name ~ " resource") }}",
+
+            attributes: (
+{% for field in resource.fields %}
+                {{ field.name }}: (
+                    type: "{{ field.field_type | jcl_type }}",
+{% if field.required %}
+                    required: true,
+{% else %}
+                    optional: true,
+{% endif %}
+{% if field.sensitive %}
+                    sensitive: true,
+{% endif %}
+{% if field.immutable %}
+                    force_new: true,
+{% endif %}
+{% if field.description %}
+                    description: "{{ field.description }}",
+{% endif %}
+                ),
+{% endfor %}
+{% for output in resource.outputs %}
+                {{ output.name }}: (
+                    type: "{{ output.field_type | jcl_type }}",
+                    computed: true,
+{% if output.description %}
+                    description: "{{ output.description }}",
+{% endif %}
+                ),
+{% endfor %}
+            ),
+
+            capabilities: (
+                create: {% if resource.operations.create %}true{% else %}false{% endif %},
+                read: {% if resource.operations.read %}true{% else %}false{% endif %},
+                update: {% if resource.operations.update %}true{% else %}false{% endif %},
+                delete: {% if resource.operations.delete %}true{% else %}false{% endif %},
+            ),
+        ),
+{% endfor %}
+    ),
+)

--- a/crates/generator/templates/unified_Cargo.toml.tera
+++ b/crates/generator/templates/unified_Cargo.toml.tera
@@ -2,22 +2,25 @@
 name = "hemmer-{{ provider_name }}-provider"
 version = "0.1.0"
 edition = "2021"
+description = "Hemmer unified provider for {{ provider_name }}"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+name = "hemmer_{{ provider_name }}_provider"
+path = "src/lib.rs"
+
+[[bin]]
+name = "hemmer-{{ provider_name }}-provider"
+path = "src/main.rs"
 
 [dependencies]
-# Hemmer provider runtime
-hemmer-provider = { path = "../../hemmer/crates/hemmer-provider" }
-hemmer-core = { path = "../../hemmer/crates/hemmer-core" }
-async-trait = "0.1"
+# Hemmer provider SDK
+hemmer-provider-sdk = "0.1"
 
-# SDK dependencies for all services
+# Cloud SDK dependencies
 {% if provider == "Kubernetes" %}# Kubernetes SDK dependencies (special case - uses shared kube client)
 kube = { version = "0.87", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.20", features = ["v1_28"] }
-{% else %}# Cloud provider SDK dependencies
-{% for service in services -%}
+{% else %}{% for service in services -%}
 {%- set dep = provider | sdk_dependency(service_name=service.name) -%}
 {%- if dep != "" %}{{ dep }} = "1"
 {% endif -%}
@@ -26,10 +29,11 @@ k8s-openapi = { version = "0.20", features = ["v1_28"] }
 
 # Standard dependencies
 anyhow = "1"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/generator/templates/unified_lib.rs.tera
+++ b/crates/generator/templates/unified_lib.rs.tera
@@ -9,242 +9,269 @@
 {% for service in services %}pub mod {{ service.name }};
 {% endfor %}
 
-use async_trait::async_trait;
-use hemmer_core::Result;
-use hemmer_provider::{ProviderConfig, ProviderExecutor, ResourceInput, ResourceOutput, ResourcePlan};
-use thiserror::Error;
+use hemmer_provider_sdk::{
+    Attribute, AttributeFlags, AttributeType, Block, PlanResult, ProviderSchema, ProviderService,
+    Schema,
+};
+use std::collections::HashMap;
 
-/// Provider error types
-#[derive(Error, Debug)]
-pub enum ProviderError {
-    #[error("Resource not found: {0}")]
-    NotFound(String),
-
-    #[error("SDK error: {0}")]
-    SdkError(String),
-
-    #[error("Validation error: {0}")]
-    ValidationError(String),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
-
-/// Result type for provider operations
-pub type Result<T> = std::result::Result<T, ProviderError>;
-
-/// Unified provider client for {{ provider_name | capitalize }}
+/// Unified provider for {{ provider_name | capitalize }}
 pub struct {{ provider_name | capitalize }}Provider {
-{% if provider == "Aws" %}{% for service in services %}    {{ service.name }}_client: aws_sdk_{{ service.name }}::Client,
-{% endfor %}    /// Tokio runtime for async operations
-    /// Each provider instance owns its own runtime to ensure async operations
-    /// work correctly when loaded as a dynamic library (cdylib)
-    runtime: tokio::runtime::Runtime,
-{% elif provider == "Gcp" %}    // GCP clients
-{% for service in services %}    // {{ service.name }}_client: google_{{ service.name }}::Client,
-{% endfor %}    runtime: tokio::runtime::Runtime,
-{% elif provider == "Azure" %}    // Azure clients
-{% for service in services %}    // {{ service.name }}_client: azure_{{ service.name }}::Client,
-{% endfor %}    runtime: tokio::runtime::Runtime,
-{% elif provider == "Kubernetes" %}    kube_client: kube::Client,
-    runtime: tokio::runtime::Runtime,
-{% endif %}
+    config: HashMap<String, String>,
 }
 
 impl {{ provider_name | capitalize }}Provider {
-    /// Create a new unified provider instance
-    pub fn new() -> Result<Self> {
-        // Create Tokio runtime for async operations
-        // This ensures async AWS SDK calls work when the provider is loaded as a dynamic library
-        let runtime = tokio::runtime::Runtime::new()
-            .map_err(|e| ProviderError::SdkError(format!("Failed to create Tokio runtime: {}", e)))?;
+    /// Create a new provider instance
+    pub fn new() -> Self {
+        Self {
+            config: HashMap::new(),
+        }
+    }
 
-{% if provider == "Aws" %}        // Load AWS config and initialize clients using the runtime
-        let (config{% for service in services %}, {{ service.name }}_client{% endfor %}) = runtime.block_on(async {
-            let config = aws_config::load_from_env().await;
-{% for service in services %}            let {{ service.name }}_client = aws_sdk_{{ service.name }}::Client::new(&config);
-{% endfor %}            (config{% for service in services %}, {{ service.name }}_client{% endfor %})
-        });
-
-{% elif provider == "Kubernetes" %}        // Initialize Kubernetes client using the runtime
-        let kube_client = runtime.block_on(async {
-            kube::Client::try_default()
-                .await
-                .map_err(|e| ProviderError::SdkError(format!("Failed to create kube client: {}", e)))
-        })?;
-
-{% endif %}        Ok(Self {
-{% if provider == "Aws" %}{% for service in services %}            {{ service.name }}_client,
-{% endfor %}            runtime,
-{% elif provider == "Kubernetes" %}            kube_client,
-            runtime,
+    /// Build the provider schema
+    fn build_schema() -> ProviderSchema {
+        ProviderSchema {
+            provider: Schema {
+                version: 1,
+                block: Block {
+                    attributes: vec![
+{% if provider == "Aws" %}
+                        Attribute {
+                            name: "region".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("AWS region to use".to_string()),
+                        },
+                        Attribute {
+                            name: "profile".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("AWS profile to use".to_string()),
+                        },
+{% elif provider == "Gcp" %}
+                        Attribute {
+                            name: "project".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("GCP project ID".to_string()),
+                        },
+                        Attribute {
+                            name: "region".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("GCP region to use".to_string()),
+                        },
+{% elif provider == "Azure" %}
+                        Attribute {
+                            name: "subscription_id".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("Azure subscription ID".to_string()),
+                        },
+                        Attribute {
+                            name: "tenant_id".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("Azure tenant ID".to_string()),
+                        },
+{% elif provider == "Kubernetes" %}
+                        Attribute {
+                            name: "kubeconfig".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("Path to kubeconfig file".to_string()),
+                        },
+                        Attribute {
+                            name: "context".to_string(),
+                            attr_type: AttributeType::String,
+                            flags: AttributeFlags::OPTIONAL,
+                            description: Some("Kubernetes context to use".to_string()),
+                        },
 {% endif %}
-        })
+                    ],
+                    block_types: vec![],
+                },
+            },
+            resources: Self::build_resource_schemas(),
+            data_sources: HashMap::new(),
+        }
     }
 
-{% for service in services %}    /// Get {{ service.name }} service handler
-    pub fn {{ service.name }}(&self) -> {{ service.name }}::{{ service.name | capitalize }}Service<'_> {
-        {{ service.name }}::{{ service.name | capitalize }}Service::new(self)
-    }
+    /// Build resource schemas for all services
+    fn build_resource_schemas() -> HashMap<String, Schema> {
+        let mut resources = HashMap::new();
+{% for service in services %}
+{% for resource in service.resources %}
+
+        // {{ service.name }}.{{ resource.name }}
+        resources.insert(
+            "{{ service.name }}_{{ resource.name }}".to_string(),
+            Schema {
+                version: 1,
+                block: Block {
+                    attributes: vec![
+{% for field in resource.fields %}
+                        Attribute {
+                            name: "{{ field.name }}".to_string(),
+                            attr_type: AttributeType::{{ field.field_type | sdk_attr_type }},
+                            flags: {% if field.required %}AttributeFlags::REQUIRED{% else %}AttributeFlags::OPTIONAL{% endif %}{% if field.sensitive %} | AttributeFlags::SENSITIVE{% endif %}{% if field.immutable %} | AttributeFlags::FORCE_NEW{% endif %},
+                            description: {% if field.description %}Some("{{ field.description }}".to_string()){% else %}None{% endif %},
+                        },
+{% endfor %}
+{% for output in resource.outputs %}
+                        Attribute {
+                            name: "{{ output.name }}".to_string(),
+                            attr_type: AttributeType::{{ output.field_type | sdk_attr_type }},
+                            flags: AttributeFlags::COMPUTED,
+                            description: {% if output.description %}Some("{{ output.description }}".to_string()){% else %}None{% endif %},
+                        },
+{% endfor %}
+                    ],
+                    block_types: vec![],
+                },
+            },
+        );
+{% endfor %}
 {% endfor %}
 
-    /// Get reference to the Tokio runtime for executing async operations
-    pub(crate) fn runtime(&self) -> &tokio::runtime::Runtime {
-        &self.runtime
+        resources
     }
 }
 
-/// Implement ProviderExecutor trait for Hemmer integration
-#[async_trait]
-impl ProviderExecutor for {{ provider_name | capitalize }}Provider {
-    /// Configure the provider with authentication and settings
-    async fn configure(&mut self, config: ProviderConfig) -> Result<()> {
-        // Configuration is already handled in new()
-        // Additional runtime configuration can be added here
+impl Default for {{ provider_name | capitalize }}Provider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProviderService for {{ provider_name | capitalize }}Provider {
+    fn schema(&self) -> ProviderSchema {
+        Self::build_schema()
+    }
+
+    fn configure(&mut self, config: HashMap<String, serde_json::Value>) -> Result<(), String> {
+        for (key, value) in config {
+            if let serde_json::Value::String(s) = value {
+                self.config.insert(key, s);
+            }
+        }
         Ok(())
     }
 
-    /// Plan changes to a resource (diff current vs desired state)
-    async fn plan(
+    fn plan(
         &self,
         resource_type: &str,
-        current_state: Option<&ResourceOutput>,
-        desired_input: &ResourceInput,
-    ) -> Result<ResourcePlan> {
-        // Dispatch to appropriate service based on resource_type
-        // Format: "service_name.resource_name" (e.g., "s3.bucket")
-        let parts: Vec<&str> = resource_type.split('.').collect();
-        if parts.len() != 2 {
-            return Err(hemmer_core::HemmerError::Provider(format!(
-                "Invalid resource type format: {}. Expected 'service.resource'",
-                resource_type
-            )));
+        _prior_state: Option<serde_json::Value>,
+        proposed: serde_json::Value,
+    ) -> Result<PlanResult, String> {
+        // Parse resource type: service_resource format
+        let parts: Vec<&str> = resource_type.split('_').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid resource type: {}", resource_type));
+        }
+
+        // Return the proposed state as the planned state
+        Ok(PlanResult {
+            planned_state: proposed,
+            requires_replace: vec![],
+        })
+    }
+
+    async fn create(
+        &self,
+        resource_type: &str,
+        planned: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        // Parse resource type: service_resource format
+        let parts: Vec<&str> = resource_type.split('_').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid resource type: {}", resource_type));
         }
 
         let service_name = parts[0];
-        let resource_name = parts[1];
+        let resource_name = parts[1..].join("_");
 
         match service_name {
-{% for service in services %}            "{{ service.name }}" => {
-                self.{{ service.name }}().plan_resource(resource_name, current_state, desired_input).await
+{% for service in services %}
+            "{{ service.name }}" => {
+                {{ service.name }}::create_resource(&resource_name, &self.config, planned).await
             }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown service: {}",
-                service_name
-            ))),
+{% endfor %}
+            _ => Err(format!("Unknown service: {}", service_name)),
         }
     }
 
-    /// Create a new resource
-    async fn create(&self, resource_type: &str, input: ResourceInput) -> Result<ResourceOutput> {
-        let parts: Vec<&str> = resource_type.split('.').collect();
-        if parts.len() != 2 {
-            return Err(hemmer_core::HemmerError::Provider(format!(
-                "Invalid resource type format: {}. Expected 'service.resource'",
-                resource_type
-            )));
+    async fn read(
+        &self,
+        resource_type: &str,
+        current: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        // Parse resource type: service_resource format
+        let parts: Vec<&str> = resource_type.split('_').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid resource type: {}", resource_type));
         }
 
         let service_name = parts[0];
-        let resource_name = parts[1];
+        let resource_name = parts[1..].join("_");
 
         match service_name {
-{% for service in services %}            "{{ service.name }}" => {
-                self.{{ service.name }}().create_resource(resource_name, input).await
+{% for service in services %}
+            "{{ service.name }}" => {
+                {{ service.name }}::read_resource(&resource_name, &self.config, current).await
             }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown service: {}",
-                service_name
-            ))),
+{% endfor %}
+            _ => Err(format!("Unknown service: {}", service_name)),
         }
     }
 
-    /// Read/refresh resource state
-    async fn read(&self, resource_type: &str, id: &str) -> Result<ResourceOutput> {
-        let parts: Vec<&str> = resource_type.split('.').collect();
-        if parts.len() != 2 {
-            return Err(hemmer_core::HemmerError::Provider(format!(
-                "Invalid resource type format: {}. Expected 'service.resource'",
-                resource_type
-            )));
-        }
-
-        let service_name = parts[0];
-        let resource_name = parts[1];
-
-        match service_name {
-{% for service in services %}            "{{ service.name }}" => {
-                self.{{ service.name }}().read_resource(resource_name, id).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown service: {}",
-                service_name
-            ))),
-        }
-    }
-
-    /// Update an existing resource
     async fn update(
         &self,
         resource_type: &str,
-        id: &str,
-        input: ResourceInput,
-    ) -> Result<ResourceOutput> {
-        let parts: Vec<&str> = resource_type.split('.').collect();
-        if parts.len() != 2 {
-            return Err(hemmer_core::HemmerError::Provider(format!(
-                "Invalid resource type format: {}. Expected 'service.resource'",
-                resource_type
-            )));
+        _prior: serde_json::Value,
+        planned: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        // Parse resource type: service_resource format
+        let parts: Vec<&str> = resource_type.split('_').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid resource type: {}", resource_type));
         }
 
         let service_name = parts[0];
-        let resource_name = parts[1];
+        let resource_name = parts[1..].join("_");
 
         match service_name {
-{% for service in services %}            "{{ service.name }}" => {
-                self.{{ service.name }}().update_resource(resource_name, id, input).await
+{% for service in services %}
+            "{{ service.name }}" => {
+                {{ service.name }}::update_resource(&resource_name, &self.config, planned).await
             }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown service: {}",
-                service_name
-            ))),
+{% endfor %}
+            _ => Err(format!("Unknown service: {}", service_name)),
         }
     }
 
-    /// Delete a resource
-    async fn delete(&self, resource_type: &str, id: &str) -> Result<()> {
-        let parts: Vec<&str> = resource_type.split('.').collect();
-        if parts.len() != 2 {
-            return Err(hemmer_core::HemmerError::Provider(format!(
-                "Invalid resource type format: {}. Expected 'service.resource'",
-                resource_type
-            )));
+    async fn delete(
+        &self,
+        resource_type: &str,
+        current: serde_json::Value,
+    ) -> Result<(), String> {
+        // Parse resource type: service_resource format
+        let parts: Vec<&str> = resource_type.split('_').collect();
+        if parts.len() < 2 {
+            return Err(format!("Invalid resource type: {}", resource_type));
         }
 
         let service_name = parts[0];
-        let resource_name = parts[1];
+        let resource_name = parts[1..].join("_");
 
         match service_name {
-{% for service in services %}            "{{ service.name }}" => {
-                self.{{ service.name }}().delete_resource(resource_name, id).await
+{% for service in services %}
+            "{{ service.name }}" => {
+                {{ service.name }}::delete_resource(&resource_name, &self.config, current).await
             }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown service: {}",
-                service_name
-            ))),
+{% endfor %}
+            _ => Err(format!("Unknown service: {}", service_name)),
         }
-    }
-}
-
-/// Factory function to create a provider instance
-///
-/// This is the entry point called by Hemmer when loading the provider as a dynamic library.
-#[no_mangle]
-pub extern "C" fn create_provider() -> *mut dyn ProviderExecutor {
-    match {{ provider_name | capitalize }}Provider::new() {
-        Ok(provider) => Box::into_raw(Box::new(provider)) as *mut dyn ProviderExecutor,
-        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -254,9 +281,22 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        // Provider creation test
-        // Note: This will fail without proper credentials
-        // let provider = {{ provider_name | capitalize }}Provider::new();
-        // assert!(provider.is_ok());
+        let provider = {{ provider_name | capitalize }}Provider::new();
+        let schema = provider.schema();
+        assert!(!schema.resources.is_empty());
+    }
+
+    #[test]
+    fn test_schema_has_resources() {
+        let provider = {{ provider_name | capitalize }}Provider::new();
+        let schema = provider.schema();
+{% for service in services %}
+{% for resource in service.resources %}
+        assert!(
+            schema.resources.contains_key("{{ service.name }}_{{ resource.name }}"),
+            "Schema should contain {{ service.name }}_{{ resource.name }}"
+        );
+{% endfor %}
+{% endfor %}
     }
 }

--- a/crates/generator/templates/unified_main.rs.tera
+++ b/crates/generator/templates/unified_main.rs.tera
@@ -1,0 +1,24 @@
+//! {{ provider_name | capitalize }} Provider - Entry Point
+//!
+//! Auto-generated unified provider from {{ provider_name }} SDK version {{ sdk_version }}
+//!
+//! This provider includes multiple services:
+{% for service in services %}//! - {{ service.name }}
+{% endfor %}
+
+use hemmer_provider_sdk::serve;
+
+// Import from the library crate
+use hemmer_{{ provider_name }}_provider::{{ provider_name | capitalize }}Provider;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
+    hemmer_provider_sdk::init_logging_with_default();
+
+    // Create and serve the provider
+    let provider = {{ provider_name | capitalize }}Provider::new();
+    serve(provider).await?;
+
+    Ok(())
+}

--- a/crates/generator/templates/unified_provider.jcf.tera
+++ b/crates/generator/templates/unified_provider.jcf.tera
@@ -1,0 +1,114 @@
+# {{ provider_name | capitalize }} Provider
+# Generated from {{ provider_name }} SDK version {{ sdk_version }}
+#
+# This unified provider implements CRUD operations for multiple services.
+
+provider = (
+    name: "{{ provider_name }}",
+    version: "{{ sdk_version }}",
+    protocol: "grpc",
+
+    # Provider configuration schema
+    config: (
+{% if provider == "Aws" %}
+        region: (
+            type: "string",
+            optional: true,
+            description: "AWS region to use",
+        ),
+        profile: (
+            type: "string",
+            optional: true,
+            description: "AWS profile to use",
+        ),
+{% elif provider == "Gcp" %}
+        project: (
+            type: "string",
+            optional: true,
+            description: "GCP project ID",
+        ),
+        region: (
+            type: "string",
+            optional: true,
+            description: "GCP region to use",
+        ),
+{% elif provider == "Azure" %}
+        subscription_id: (
+            type: "string",
+            optional: true,
+            description: "Azure subscription ID",
+        ),
+        tenant_id: (
+            type: "string",
+            optional: true,
+            description: "Azure tenant ID",
+        ),
+{% elif provider == "Kubernetes" %}
+        kubeconfig: (
+            type: "string",
+            optional: true,
+            description: "Path to kubeconfig file",
+        ),
+        context: (
+            type: "string",
+            optional: true,
+            description: "Kubernetes context to use",
+        ),
+{% endif %}
+    ),
+
+    # Services
+    services: (
+{% for service in services %}
+        {{ service.name }}: (
+            description: "{{ service.name | capitalize }} service resources",
+
+            resources: (
+{% for resource in service.resources %}
+                {{ resource.name }}: (
+                    description: "{{ resource.description | default(value=resource.name ~ " resource") }}",
+
+                    attributes: (
+{% for field in resource.fields %}
+                        {{ field.name }}: (
+                            type: "{{ field.field_type | jcl_type }}",
+{% if field.required %}
+                            required: true,
+{% else %}
+                            optional: true,
+{% endif %}
+{% if field.sensitive %}
+                            sensitive: true,
+{% endif %}
+{% if field.immutable %}
+                            force_new: true,
+{% endif %}
+{% if field.description %}
+                            description: "{{ field.description }}",
+{% endif %}
+                        ),
+{% endfor %}
+{% for output in resource.outputs %}
+                        {{ output.name }}: (
+                            type: "{{ output.field_type | jcl_type }}",
+                            computed: true,
+{% if output.description %}
+                            description: "{{ output.description }}",
+{% endif %}
+                        ),
+{% endfor %}
+                    ),
+
+                    capabilities: (
+                        create: {% if resource.operations.create %}true{% else %}false{% endif %},
+                        read: {% if resource.operations.read %}true{% else %}false{% endif %},
+                        update: {% if resource.operations.update %}true{% else %}false{% endif %},
+                        delete: {% if resource.operations.delete %}true{% else %}false{% endif %},
+                    ),
+                ),
+{% endfor %}
+            ),
+        ),
+{% endfor %}
+    ),
+)

--- a/crates/generator/templates/unified_resource.rs.tera
+++ b/crates/generator/templates/unified_resource.rs.tera
@@ -2,91 +2,159 @@
 //!
 //! {{ resource.description | default(value="Auto-generated resource") }}
 
-use crate::{ProviderError, Result};
 use std::collections::HashMap;
 
-/// {{ resource.name | capitalize }} resource handler
-pub struct {{ resource.name | capitalize }}<'a> {
-    provider: &'a crate::{{ provider_name | capitalize }}Provider,
+/// Create a new {{ resource.name }}
+#[allow(unused_variables)]
+pub async fn create(
+    config: &HashMap<String, String>,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+{% if provider == "Aws" %}
+    // Extract input fields
+{% for field in resource.fields %}
+{% if field.required %}
+    let {{ field.name }} = input.get("{{ field.name }}")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing required field: {{ field.name }}".to_string())?;
+{% else %}
+    let {{ field.name }} = input.get("{{ field.name }}")
+        .and_then(|v| v.as_str());
+{% endif %}
+{% endfor %}
+
+    // TODO: Initialize AWS SDK client using config
+    // let sdk_config = aws_config::from_env()
+    //     .region(config.get("region").map(|s| Region::new(s.clone())))
+    //     .load()
+    //     .await;
+    // let client = aws_sdk_{{ service_name }}::Client::new(&sdk_config);
+
+    // TODO: Call AWS SDK to create the resource
+    // let result = client
+    //     .create_{{ resource.name }}()
+{% for field in resource.fields %}
+    //     .{{ field.name }}({{ field.name }})
+{% endfor %}
+    //     .send()
+    //     .await
+    //     .map_err(|e| format!("Failed to create {{ resource.name }}: {}", e))?;
+
+    // Return placeholder output with computed fields
+    let mut output = input.clone();
+{% for output_field in resource.outputs %}
+    output.as_object_mut()
+        .ok_or_else(|| "Invalid input format".to_string())?
+        .insert("{{ output_field.name }}".to_string(), serde_json::json!("placeholder-{{ output_field.name }}"));
+{% endfor %}
+
+    Ok(output)
+{% else %}
+    // TODO: Implement create for {{ provider }}
+    Err("Not implemented".to_string())
+{% endif %}
 }
 
-impl<'a> {{ resource.name | capitalize }}<'a> {
-    pub(crate) fn new(provider: &'a crate::{{ provider_name | capitalize }}Provider) -> Self {
-        Self { provider }
-    }
-
-{% if resource.operations.create %}
-    /// Create a new {{ resource.name }}
-    ///
-    /// Note: Parameter types are simplified. SDK may require specific enums/types.
-    /// TODO: Convert String parameters to appropriate SDK types as needed.
-    #[allow(unused_variables)]
-    pub async fn create(&self{% for field in resource.fields %}, {{ field.name }}: {% if field.required %}{{ field.field_type | rust_type }}{% else %}Option<{{ field.field_type | rust_type }}>{% endif %}{% endfor %}) -> Result<String> {
+/// Read a {{ resource.name }}
+#[allow(unused_variables)]
+pub async fn read(
+    config: &HashMap<String, String>,
+    current: serde_json::Value,
+) -> Result<serde_json::Value, String> {
 {% if provider == "Aws" %}
-        // Note: This is a generated skeleton. Type conversions may be needed.
-        // TODO: Implement actual SDK call with proper type mapping
-        let _client = &self.provider.{{ service_name }}_client;
+    // TODO: Initialize AWS SDK client using config
+    // let sdk_config = aws_config::from_env()
+    //     .region(config.get("region").map(|s| Region::new(s.clone())))
+    //     .load()
+    //     .await;
+    // let client = aws_sdk_{{ service_name }}::Client::new(&sdk_config);
 
-        // Placeholder: Real implementation needs SDK-specific type conversion
-        Ok(format!("{{ resource.name }}_created"))
+    // TODO: Call AWS SDK to read the resource
+    // Extract identifier from current state
+    // let id = current.get("id").and_then(|v| v.as_str());
+    // let result = client
+    //     .describe_{{ resource.name }}()
+    //     .send()
+    //     .await
+    //     .map_err(|e| format!("Failed to read {{ resource.name }}: {}", e))?;
+
+    // Return current state (refresh would update from API)
+    Ok(current)
 {% else %}
-        todo!("Implement create for {{ provider }}")
+    // TODO: Implement read for {{ provider }}
+    Err("Not implemented".to_string())
 {% endif %}
-    }
-{% endif %}
+}
 
-{% if resource.operations.read %}
-    /// Read/describe a {{ resource.name }}
-    ///
-    /// TODO: Map `id` parameter to appropriate SDK field(s)
-    #[allow(unused_variables)]
-    pub async fn read(&self, id: &str) -> Result<()> {
+/// Update a {{ resource.name }}
+#[allow(unused_variables)]
+pub async fn update(
+    config: &HashMap<String, String>,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
 {% if provider == "Aws" %}
-        // Note: This is a generated skeleton.
-        // TODO: Map resource ID to SDK parameters
-        let _client = &self.provider.{{ service_name }}_client;
+    // Extract input fields
+{% for field in resource.fields %}
+{% if not field.immutable %}
+    let {{ field.name }} = input.get("{{ field.name }}")
+        .and_then(|v| v.as_str());
+{% endif %}
+{% endfor %}
 
-        Ok(())
+    // TODO: Initialize AWS SDK client using config
+    // let sdk_config = aws_config::from_env()
+    //     .region(config.get("region").map(|s| Region::new(s.clone())))
+    //     .load()
+    //     .await;
+    // let client = aws_sdk_{{ service_name }}::Client::new(&sdk_config);
+
+    // TODO: Call AWS SDK to update the resource
+    // let result = client
+    //     .update_{{ resource.name }}()
+{% for field in resource.fields %}
+{% if not field.immutable %}
+    //     .{{ field.name }}({{ field.name }})
+{% endif %}
+{% endfor %}
+    //     .send()
+    //     .await
+    //     .map_err(|e| format!("Failed to update {{ resource.name }}: {}", e))?;
+
+    // Return updated state
+    Ok(input)
 {% else %}
-        todo!("Implement read for {{ provider }}")
+    // TODO: Implement update for {{ provider }}
+    Err("Not implemented".to_string())
 {% endif %}
-    }
-{% endif %}
+}
 
-{% if resource.operations.update %}
-    /// Update a {{ resource.name }}
-    ///
-    /// TODO: Map `id` and update fields to appropriate SDK parameters
-    #[allow(unused_variables)]
-    pub async fn update(&self, id: &str{% for field in resource.fields %}{% if not field.immutable %}, {{ field.name }}: Option<{{ field.field_type | rust_type }}>{% endif %}{% endfor %}) -> Result<()> {
+/// Delete a {{ resource.name }}
+#[allow(unused_variables)]
+pub async fn delete(
+    config: &HashMap<String, String>,
+    current: serde_json::Value,
+) -> Result<(), String> {
 {% if provider == "Aws" %}
-        // Note: This is a generated skeleton.
-        // TODO: Map resource ID and update fields to SDK parameters
-        let _client = &self.provider.{{ service_name }}_client;
+    // TODO: Initialize AWS SDK client using config
+    // let sdk_config = aws_config::from_env()
+    //     .region(config.get("region").map(|s| Region::new(s.clone())))
+    //     .load()
+    //     .await;
+    // let client = aws_sdk_{{ service_name }}::Client::new(&sdk_config);
 
-        Ok(())
+    // TODO: Call AWS SDK to delete the resource
+    // Extract identifier from current state
+    // let id = current.get("id").and_then(|v| v.as_str());
+    // client
+    //     .delete_{{ resource.name }}()
+    //     .send()
+    //     .await
+    //     .map_err(|e| format!("Failed to delete {{ resource.name }}: {}", e))?;
+
+    Ok(())
 {% else %}
-        todo!("Implement update for {{ provider }}")
-{% endif %}
-    }
-{% endif %}
-
-{% if resource.operations.delete %}
-    /// Delete a {{ resource.name }}
-    ///
-    /// TODO: Map `id` parameter to appropriate SDK field(s)
-    #[allow(unused_variables)]
-    pub async fn delete(&self, id: &str) -> Result<()> {
-{% if provider == "Aws" %}
-        // Note: This is a generated skeleton.
-        // TODO: Map resource ID to SDK parameters
-        let _client = &self.provider.{{ service_name }}_client;
-
-        Ok(())
-{% else %}
-        todo!("Implement delete for {{ provider }}")
-{% endif %}
-    }
+    // TODO: Implement delete for {{ provider }}
+    Err("Not implemented".to_string())
 {% endif %}
 }
 
@@ -95,7 +163,17 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_{{ resource.name }}_operations() {
-        // Test {{ resource.name }} CRUD operations
+    async fn test_{{ resource.name }}_create() {
+        // Test {{ resource.name }} create operation
+        let config = HashMap::new();
+        let input = serde_json::json!({
+{% for field in resource.fields %}
+            "{{ field.name }}": "test-value",
+{% endfor %}
+        });
+
+        // Note: This will fail without actual AWS credentials
+        // let result = create(&config, input).await;
+        // assert!(result.is_ok());
     }
 }

--- a/crates/generator/templates/unified_service.rs.tera
+++ b/crates/generator/templates/unified_service.rs.tera
@@ -2,246 +2,62 @@
 //!
 //! This module handles all {{ service.name }} resources and their CRUD operations.
 
-use hemmer_core::Result;
-use hemmer_provider::{ResourceInput, ResourceOutput, ResourcePlan};
+pub mod resources;
 
-/// {{ service.name | capitalize }} service handler
-pub struct {{ service.name | capitalize }}Service<'a> {
-    provider: &'a crate::{{ provider_name | capitalize }}Provider,
+use std::collections::HashMap;
+
+/// Create a resource in the {{ service.name }} service
+pub async fn create_resource(
+    resource_name: &str,
+    config: &HashMap<String, String>,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    match resource_name {
+{% for resource in service.resources %}
+        "{{ resource.name }}" => resources::{{ resource.name }}::create(config, input).await,
+{% endfor %}
+        _ => Err(format!("Unknown resource: {}.{}", "{{ service.name }}", resource_name)),
+    }
 }
 
-impl<'a> {{ service.name | capitalize }}Service<'a> {
-    /// Create a new service handler
-    pub fn new(provider: &'a crate::{{ provider_name | capitalize }}Provider) -> Self {
-        Self { provider }
-    }
-
-    /// Plan changes to a resource
-    pub async fn plan_resource(
-        &self,
-        resource_name: &str,
-        current_state: Option<&ResourceOutput>,
-        desired_input: &ResourceInput,
-    ) -> Result<ResourcePlan> {
-        match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
-                self.plan_{{ resource.name | sanitize_identifier_part }}(current_state, desired_input).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown resource type: {}.{}",
-                "{{ service.name }}",
-                resource_name
-            ))),
-        }
-    }
-
-    /// Create a new resource
-    pub async fn create_resource(
-        &self,
-        resource_name: &str,
-        input: ResourceInput,
-    ) -> Result<ResourceOutput> {
-        match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
-                self.create_{{ resource.name | sanitize_identifier_part }}(input).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown resource type: {}.{}",
-                "{{ service.name }}",
-                resource_name
-            ))),
-        }
-    }
-
-    /// Read resource state
-    pub async fn read_resource(
-        &self,
-        resource_name: &str,
-        id: &str,
-    ) -> Result<ResourceOutput> {
-        match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
-                self.read_{{ resource.name | sanitize_identifier_part }}(id).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown resource type: {}.{}",
-                "{{ service.name }}",
-                resource_name
-            ))),
-        }
-    }
-
-    /// Update an existing resource
-    pub async fn update_resource(
-        &self,
-        resource_name: &str,
-        id: &str,
-        input: ResourceInput,
-    ) -> Result<ResourceOutput> {
-        match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
-                self.update_{{ resource.name | sanitize_identifier_part }}(id, input).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown resource type: {}.{}",
-                "{{ service.name }}",
-                resource_name
-            ))),
-        }
-    }
-
-    /// Delete a resource
-    pub async fn delete_resource(
-        &self,
-        resource_name: &str,
-        id: &str,
-    ) -> Result<()> {
-        match resource_name {
-{% for resource in service.resources %}            "{{ resource.name | sanitize_identifier_part }}" => {
-                self.delete_{{ resource.name | sanitize_identifier_part }}(id).await
-            }
-{% endfor %}            _ => Err(hemmer_core::HemmerError::Provider(format!(
-                "Unknown resource type: {}.{}",
-                "{{ service.name }}",
-                resource_name
-            ))),
-        }
-    }
-
-    // ========================================================================
-    // Resource-specific CRUD implementations
-    // ========================================================================
-
+/// Read a resource in the {{ service.name }} service
+pub async fn read_resource(
+    resource_name: &str,
+    config: &HashMap<String, String>,
+    current: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    match resource_name {
 {% for resource in service.resources %}
-    // ------------------------------------------------------------------------
-    // {{ resource.name | capitalize }} resource operations
-    // ------------------------------------------------------------------------
-
-    /// Plan changes to a {{ resource.name }} resource
-    async fn plan_{{ resource.name | sanitize_identifier_part }}(
-        &self,
-        current_state: Option<&ResourceOutput>,
-        desired_input: &ResourceInput,
-    ) -> Result<ResourcePlan> {
-        // If no current state exists, this is a create operation
-        if current_state.is_none() {
-            return Ok(ResourcePlan::create());
-        }
-
-        // TODO: Implement proper diff logic
-        // For now, return NoOp if resource exists
-        Ok(ResourcePlan::no_op())
-    }
-
-    /// Create a new {{ resource.name }} resource
-    async fn create_{{ resource.name | sanitize_identifier_part }}(
-        &self,
-        input: ResourceInput,
-    ) -> Result<ResourceOutput> {
-{% if provider == "Aws" %}        // Use the runtime to execute async SDK calls
-        self.provider.runtime().block_on(async {
-            // Extract input fields
-{% for field in resource.fields %}{% if field.required %}            let {{ field.name | sanitize_identifier }} = input.get_string("{{ field.name }}")?;
-{% else %}            let {{ field.name | sanitize_identifier }} = input.get_optional_string("{{ field.name }}")?;
-{% endif %}{% endfor %}
-
-            // TODO: Call AWS SDK to create the resource
-            // Example:
-            // let result = self.provider.{{ service.name }}_client
-            //     .create_{{ resource.name | sanitize_identifier }}()
-            //     .set_name(name)
-            //     .send()
-            //     .await
-            //     .map_err(|e| hemmer_core::HemmerError::Provider(format!("Failed to create resource: {}", e)))?;
-
-            // Return placeholder output
-            Ok(ResourceOutput::new()
-                .with_id("placeholder-id")
-{% for field in resource.fields %}                .with_field("{{ field.name }}", {{ field.name | sanitize_identifier }}.unwrap_or_default())
-{% endfor %}            )
-        })
-{% else %}        // TODO: Implement {{ provider }} SDK calls
-        Ok(ResourceOutput::new()
-            .with_id("placeholder-id"))
-{% endif %}    }
-
-    /// Read a {{ resource.name }} resource
-    async fn read_{{ resource.name | sanitize_identifier_part }}(
-        &self,
-        id: &str,
-    ) -> Result<ResourceOutput> {
-{% if provider == "Aws" %}        self.provider.runtime().block_on(async {
-            // TODO: Call AWS SDK to read the resource
-            // Example:
-            // let result = self.provider.{{ service.name }}_client
-            //     .describe_{{ resource.name | sanitize_identifier }}()
-            //     .set_id(id.to_string())
-            //     .send()
-            //     .await
-            //     .map_err(|e| hemmer_core::HemmerError::Provider(format!("Failed to read resource: {}", e)))?;
-
-            // Return placeholder output
-            Ok(ResourceOutput::new()
-                .with_id(id))
-        })
-{% else %}        // TODO: Implement {{ provider }} SDK calls
-        Ok(ResourceOutput::new()
-            .with_id(id))
-{% endif %}    }
-
-    /// Update a {{ resource.name }} resource
-    async fn update_{{ resource.name | sanitize_identifier_part }}(
-        &self,
-        id: &str,
-        input: ResourceInput,
-    ) -> Result<ResourceOutput> {
-{% if provider == "Aws" %}        self.provider.runtime().block_on(async {
-            // Extract input fields
-{% for field in resource.fields %}{% if field.required %}            let {{ field.name | sanitize_identifier }} = input.get_string("{{ field.name }}")?;
-{% else %}            let {{ field.name | sanitize_identifier }} = input.get_optional_string("{{ field.name }}")?;
-{% endif %}{% endfor %}
-
-            // TODO: Call AWS SDK to update the resource
-            // Example:
-            // let result = self.provider.{{ service.name }}_client
-            //     .update_{{ resource.name | sanitize_identifier }}()
-            //     .set_id(id.to_string())
-            //     .set_name(name)
-            //     .send()
-            //     .await
-            //     .map_err(|e| hemmer_core::HemmerError::Provider(format!("Failed to update resource: {}", e)))?;
-
-            // Return placeholder output
-            Ok(ResourceOutput::new()
-                .with_id(id)
-{% for field in resource.fields %}                .with_field("{{ field.name }}", {{ field.name | sanitize_identifier }}.unwrap_or_default())
-{% endfor %}            )
-        })
-{% else %}        // TODO: Implement {{ provider }} SDK calls
-        Ok(ResourceOutput::new()
-            .with_id(id))
-{% endif %}    }
-
-    /// Delete a {{ resource.name }} resource
-    async fn delete_{{ resource.name | sanitize_identifier_part }}(
-        &self,
-        id: &str,
-    ) -> Result<()> {
-{% if provider == "Aws" %}        self.provider.runtime().block_on(async {
-            // TODO: Call AWS SDK to delete the resource
-            // Example:
-            // self.provider.{{ service.name }}_client
-            //     .delete_{{ resource.name | sanitize_identifier }}()
-            //     .set_id(id.to_string())
-            //     .send()
-            //     .await
-            //     .map_err(|e| hemmer_core::HemmerError::Provider(format!("Failed to delete resource: {}", e)))?;
-
-            Ok(())
-        })
-{% else %}        // TODO: Implement {{ provider }} SDK calls
-        Ok(())
-{% endif %}    }
-
+        "{{ resource.name }}" => resources::{{ resource.name }}::read(config, current).await,
 {% endfor %}
+        _ => Err(format!("Unknown resource: {}.{}", "{{ service.name }}", resource_name)),
+    }
+}
+
+/// Update a resource in the {{ service.name }} service
+pub async fn update_resource(
+    resource_name: &str,
+    config: &HashMap<String, String>,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    match resource_name {
+{% for resource in service.resources %}
+        "{{ resource.name }}" => resources::{{ resource.name }}::update(config, input).await,
+{% endfor %}
+        _ => Err(format!("Unknown resource: {}.{}", "{{ service.name }}", resource_name)),
+    }
+}
+
+/// Delete a resource in the {{ service.name }} service
+pub async fn delete_resource(
+    resource_name: &str,
+    config: &HashMap<String, String>,
+    current: serde_json::Value,
+) -> Result<(), String> {
+    match resource_name {
+{% for resource in service.resources %}
+        "{{ resource.name }}" => resources::{{ resource.name }}::delete(config, current).await,
+{% endfor %}
+        _ => Err(format!("Unknown resource: {}.{}", "{{ service.name }}", resource_name)),
+    }
 }

--- a/crates/generator/tests/generation_test.rs
+++ b/crates/generator/tests/generation_test.rs
@@ -74,23 +74,94 @@ fn test_generate_s3_provider() {
     assert!(result.is_ok(), "Generation failed: {:?}", result);
 
     // Check that files were created
-    assert!(output_path.join("provider.k").exists());
-    assert!(output_path.join("Cargo.toml").exists());
-    assert!(output_path.join("README.md").exists());
-    assert!(output_path.join("src/lib.rs").exists());
-    assert!(output_path.join("src/resources/mod.rs").exists());
-    assert!(output_path.join("src/resources/bucket.rs").exists());
+    assert!(
+        output_path.join("provider.jcf").exists(),
+        "provider.jcf should exist"
+    );
+    assert!(
+        output_path.join("Cargo.toml").exists(),
+        "Cargo.toml should exist"
+    );
+    assert!(
+        output_path.join("README.md").exists(),
+        "README.md should exist"
+    );
+    assert!(
+        output_path.join("src/main.rs").exists(),
+        "src/main.rs should exist"
+    );
+    assert!(
+        output_path.join("src/lib.rs").exists(),
+        "src/lib.rs should exist"
+    );
+    assert!(
+        output_path.join("src/resources/mod.rs").exists(),
+        "src/resources/mod.rs should exist"
+    );
+    assert!(
+        output_path.join("src/resources/bucket.rs").exists(),
+        "src/resources/bucket.rs should exist"
+    );
 
-    // Check provider.k content
-    let provider_k = std::fs::read_to_string(output_path.join("provider.k")).unwrap();
-    assert!(provider_k.contains("S3Provider"));
-    assert!(provider_k.contains("Bucket"));
-    assert!(provider_k.contains("bucket: str"));
+    // Check provider.jcf content
+    let provider_jcf = std::fs::read_to_string(output_path.join("provider.jcf")).unwrap();
+    assert!(
+        provider_jcf.contains("name: \"s3\""),
+        "Should contain provider name"
+    );
+    assert!(
+        provider_jcf.contains("protocol: \"grpc\""),
+        "Should specify gRPC protocol"
+    );
+    assert!(
+        provider_jcf.contains("bucket:"),
+        "Should contain bucket resource"
+    );
 
     // Check Cargo.toml content
     let cargo_toml = std::fs::read_to_string(output_path.join("Cargo.toml")).unwrap();
-    assert!(cargo_toml.contains("hemmer-s3-provider"));
-    assert!(cargo_toml.contains("aws-sdk-s3"));
+    assert!(
+        cargo_toml.contains("hemmer-s3-provider"),
+        "Should have correct package name"
+    );
+    assert!(
+        cargo_toml.contains("aws-sdk-s3"),
+        "Should have AWS SDK dependency"
+    );
+    assert!(
+        cargo_toml.contains("hemmer-provider-sdk"),
+        "Should have Hemmer SDK dependency"
+    );
+    assert!(
+        cargo_toml.contains("[[bin]]"),
+        "Should define binary target"
+    );
+
+    // Check main.rs content
+    let main_rs = std::fs::read_to_string(output_path.join("src/main.rs")).unwrap();
+    assert!(
+        main_rs.contains("hemmer_provider_sdk::serve"),
+        "Should use SDK serve function"
+    );
+    assert!(
+        main_rs.contains("S3Provider"),
+        "Should reference provider struct"
+    );
+
+    // Check lib.rs content
+    let lib_rs = std::fs::read_to_string(output_path.join("src/lib.rs")).unwrap();
+    assert!(
+        lib_rs.contains("impl ProviderService for"),
+        "Should implement ProviderService trait"
+    );
+    assert!(
+        lib_rs.contains("fn schema(&self)"),
+        "Should implement schema method"
+    );
+    assert!(
+        lib_rs.contains("async fn create"),
+        "Should implement create method"
+    );
 
     println!("✅ Provider generated successfully to: {:?}", output_path);
 }

--- a/crates/generator/tests/unified_generation_test.rs
+++ b/crates/generator/tests/unified_generation_test.rs
@@ -138,9 +138,10 @@ fn test_generate_unified_aws_provider() {
         .expect("Failed to generate provider");
 
     // Verify top-level files exist
-    assert!(output_dir.join("provider.k").exists());
+    assert!(output_dir.join("provider.jcf").exists());
     assert!(output_dir.join("Cargo.toml").exists());
     assert!(output_dir.join("README.md").exists());
+    assert!(output_dir.join("src/main.rs").exists());
     assert!(output_dir.join("src/lib.rs").exists());
 
     // Verify docs directory and files exist
@@ -160,14 +161,15 @@ fn test_generate_unified_aws_provider() {
     assert!(output_dir.join("src/dynamodb/resources/mod.rs").exists());
     assert!(output_dir.join("src/dynamodb/resources/table.rs").exists());
 
-    // Verify content of provider.k
-    let provider_k_content =
-        fs::read_to_string(output_dir.join("provider.k")).expect("Failed to read provider.k");
-    assert!(provider_k_content.contains("AwsProvider"));
-    assert!(provider_k_content.contains("S3Service"));
-    assert!(provider_k_content.contains("DynamodbService"));
-    assert!(provider_k_content.contains("Bucket"));
-    assert!(provider_k_content.contains("Table"));
+    // Verify content of provider.jcf
+    let provider_jcf_content =
+        fs::read_to_string(output_dir.join("provider.jcf")).expect("Failed to read provider.jcf");
+    assert!(provider_jcf_content.contains("name: \"aws\""));
+    assert!(provider_jcf_content.contains("protocol: \"grpc\""));
+    assert!(provider_jcf_content.contains("s3:"));
+    assert!(provider_jcf_content.contains("dynamodb:"));
+    assert!(provider_jcf_content.contains("bucket:"));
+    assert!(provider_jcf_content.contains("table:"));
 
     // Verify content of Cargo.toml
     let cargo_toml_content =
@@ -175,6 +177,14 @@ fn test_generate_unified_aws_provider() {
     assert!(cargo_toml_content.contains("hemmer-aws-provider"));
     assert!(cargo_toml_content.contains("aws-sdk-s3"));
     assert!(cargo_toml_content.contains("aws-sdk-dynamodb"));
+    assert!(cargo_toml_content.contains("hemmer-provider-sdk"));
+    assert!(cargo_toml_content.contains("[[bin]]"));
+
+    // Verify content of main.rs
+    let main_rs_content =
+        fs::read_to_string(output_dir.join("src/main.rs")).expect("Failed to read main.rs");
+    assert!(main_rs_content.contains("hemmer_provider_sdk::serve"));
+    assert!(main_rs_content.contains("AwsProvider"));
 
     // Verify content of lib.rs
     let lib_rs_content =
@@ -182,8 +192,8 @@ fn test_generate_unified_aws_provider() {
     assert!(lib_rs_content.contains("pub mod s3;"));
     assert!(lib_rs_content.contains("pub mod dynamodb;"));
     assert!(lib_rs_content.contains("pub struct AwsProvider"));
-    assert!(lib_rs_content.contains("s3_client: aws_sdk_s3::Client"));
-    assert!(lib_rs_content.contains("dynamodb_client: aws_sdk_dynamodb::Client"));
+    assert!(lib_rs_content.contains("impl ProviderService for AwsProvider"));
+    assert!(lib_rs_content.contains("fn schema(&self)"));
 
     // Clean up
     fs::remove_dir_all(&output_dir).expect("Failed to clean up test directory");
@@ -211,9 +221,10 @@ fn test_generate_unified_provider_with_empty_services() {
         .expect("Failed to generate provider");
 
     // Verify top-level files exist even with no services
-    assert!(output_dir.join("provider.k").exists());
+    assert!(output_dir.join("provider.jcf").exists());
     assert!(output_dir.join("Cargo.toml").exists());
     assert!(output_dir.join("README.md").exists());
+    assert!(output_dir.join("src/main.rs").exists());
     assert!(output_dir.join("src/lib.rs").exists());
 
     // Clean up

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -30,7 +30,9 @@ if cargo fmt --all -- --check > /dev/null 2>&1; then
 else
     echo -e "${YELLOW}Warning:${NC} Code needs formatting, auto-formatting now..."
     cargo fmt --all
-    echo -e "${GREEN}Done${NC} Code formatted successfully"
+    # Re-stage the formatted files so they're included in the commit
+    git add -u
+    echo -e "${GREEN}Done${NC} Code formatted and staged"
 fi
 
 # Check 2: Run clippy


### PR DESCRIPTION
## Summary

- Refactors provider generator to produce providers using `hemmer-provider-sdk` for gRPC communication
- Replaces KCL manifests (`provider.k`) with JCL manifests (`provider.jcf`)
- Generates standalone binary providers instead of cdylib

## Changes

### New Templates
- `main.rs.tera` - Binary entry point using `hemmer_provider_sdk::serve()`
- `provider.jcf.tera` - JCL manifest with provider config, resources, and capabilities
- `unified_main.rs.tera` - Same for multi-service providers
- `unified_provider.jcf.tera` - Same for multi-service providers

### Updated Templates
- `Cargo.toml.tera` - Added SDK dependency, binary target, removed cdylib
- `lib.rs.tera` - Implements `ProviderService` trait with schema/CRUD methods
- `unified_*.tera` - All unified templates updated similarly

### Generator Updates
- Added `jcl_type` filter for JCL type mapping
- Added `sdk_attr_type` filter for SDK AttributeType mapping
- Updated generator to produce new file structure

## Generated Provider Structure

```
provider-{service}/
├── provider.jcf              # JCL manifest (new)
├── Cargo.toml                # Binary crate with SDK dep
├── README.md
└── src/
    ├── main.rs               # Binary entry point (new)
    ├── lib.rs                # ProviderService implementation
    └── resources/
        ├── mod.rs
        └── {resource}.rs
```

## Test Plan

- [x] All 68 workspace tests pass
- [x] Clippy clean
- [x] Single-service generation test updated
- [x] Unified provider generation test updated

## Related Issues

- Closes #73
- Follow-up: #77 (generate actual SDK calls)
- Follow-up: #78 (protocol versioning support)
- Related: hemmer-io/hemmer-provider-sdk#29 (protocol versioning)
- Related: hemmer-io/hemmer#72 (provider registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)