### PR TITLE
feat: Add protocol version support using SDK 0.2

### DIFF
--- a/crates/generator/templates/Cargo.toml.tera
+++ b/crates/generator/templates/Cargo.toml.tera
@@ -13,8 +13,8 @@ name = "hemmer-{{ service_name }}-provider"
 path = "src/main.rs"
 
 [dependencies]
-# Hemmer provider SDK
-hemmer-provider-sdk = "0.1"
+# Hemmer provider SDK (0.2+ required for protocol versioning)
+hemmer-provider-sdk = "0.2"
 
 # Cloud SDK dependencies
 {% if provider == "Aws" %}aws-sdk-{{ service_name }} = "1"

--- a/crates/generator/templates/lib.rs.tera
+++ b/crates/generator/templates/lib.rs.tera
@@ -1,6 +1,9 @@
 //! {{ service_name | capitalize }} Provider for Hemmer
 //!
 //! Auto-generated from {{ provider }} SDK version {{ sdk_version }}
+//!
+//! Protocol version: Uses hemmer-provider-sdk protocol version negotiation.
+//! See [`PROTOCOL_VERSION`] for the current protocol version.
 
 pub mod resources;
 
@@ -8,10 +11,15 @@ use hemmer_provider_sdk::{
     async_trait, serde_json, tonic,
     ProviderService, ProviderSchema, Schema, Block, Attribute, AttributeType, AttributeFlags,
     PlanResult, AttributeChange, ImportedResource, ProviderMetadata, ServerCapabilities,
+    // Protocol versioning - re-export for visibility
+    PROTOCOL_VERSION, MIN_PROTOCOL_VERSION, check_protocol_version,
 };
 use std::collections::HashMap;
 use thiserror::Error;
 use tracing::{debug, error, info};
+
+// Re-export protocol version constants for consumers
+pub use hemmer_provider_sdk::{PROTOCOL_VERSION as SDK_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION as SDK_MIN_PROTOCOL_VERSION};
 
 /// Provider error types
 #[derive(Error, Debug)]

--- a/crates/generator/templates/unified_Cargo.toml.tera
+++ b/crates/generator/templates/unified_Cargo.toml.tera
@@ -13,8 +13,8 @@ name = "hemmer-{{ provider_name }}-provider"
 path = "src/main.rs"
 
 [dependencies]
-# Hemmer provider SDK
-hemmer-provider-sdk = "0.1"
+# Hemmer provider SDK (0.2+ required for protocol versioning)
+hemmer-provider-sdk = "0.2"
 
 # Cloud SDK dependencies
 {% if provider == "Kubernetes" %}# Kubernetes SDK dependencies (special case - uses shared kube client)

--- a/crates/generator/templates/unified_lib.rs.tera
+++ b/crates/generator/templates/unified_lib.rs.tera
@@ -2,6 +2,9 @@
 //!
 //! Auto-generated unified provider from {{ provider_name }} SDK version {{ sdk_version }}
 //!
+//! Protocol version: Uses hemmer-provider-sdk protocol version negotiation.
+//! See [`PROTOCOL_VERSION`] for the current protocol version.
+//!
 //! This provider includes multiple services:
 {% for service in services %}//! - {{ service.name }}
 {% endfor %}
@@ -12,8 +15,13 @@
 use hemmer_provider_sdk::{
     Attribute, AttributeFlags, AttributeType, Block, PlanResult, ProviderSchema, ProviderService,
     Schema,
+    // Protocol versioning - re-export for visibility
+    PROTOCOL_VERSION, MIN_PROTOCOL_VERSION, check_protocol_version,
 };
 use std::collections::HashMap;
+
+// Re-export protocol version constants for consumers
+pub use hemmer_provider_sdk::{PROTOCOL_VERSION as SDK_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION as SDK_MIN_PROTOCOL_VERSION};
 
 /// Unified provider for {{ provider_name | capitalize }}
 pub struct {{ provider_name | capitalize }}Provider {

--- a/crates/generator/tests/generation_test.rs
+++ b/crates/generator/tests/generation_test.rs
@@ -129,8 +129,8 @@ fn test_generate_s3_provider() {
         "Should have AWS SDK dependency"
     );
     assert!(
-        cargo_toml.contains("hemmer-provider-sdk"),
-        "Should have Hemmer SDK dependency"
+        cargo_toml.contains("hemmer-provider-sdk = \"0.2\""),
+        "Should have Hemmer SDK 0.2+ dependency for protocol versioning"
     );
     assert!(
         cargo_toml.contains("[[bin]]"),
@@ -161,6 +161,14 @@ fn test_generate_s3_provider() {
     assert!(
         lib_rs.contains("async fn create"),
         "Should implement create method"
+    );
+    assert!(
+        lib_rs.contains("PROTOCOL_VERSION"),
+        "Should import protocol version constants"
+    );
+    assert!(
+        lib_rs.contains("SDK_PROTOCOL_VERSION"),
+        "Should re-export protocol version for consumers"
     );
 
     println!("✅ Provider generated successfully to: {:?}", output_path);

--- a/crates/generator/tests/unified_generation_test.rs
+++ b/crates/generator/tests/unified_generation_test.rs
@@ -177,7 +177,7 @@ fn test_generate_unified_aws_provider() {
     assert!(cargo_toml_content.contains("hemmer-aws-provider"));
     assert!(cargo_toml_content.contains("aws-sdk-s3"));
     assert!(cargo_toml_content.contains("aws-sdk-dynamodb"));
-    assert!(cargo_toml_content.contains("hemmer-provider-sdk"));
+    assert!(cargo_toml_content.contains("hemmer-provider-sdk = \"0.2\""));
     assert!(cargo_toml_content.contains("[[bin]]"));
 
     // Verify content of main.rs
@@ -194,6 +194,8 @@ fn test_generate_unified_aws_provider() {
     assert!(lib_rs_content.contains("pub struct AwsProvider"));
     assert!(lib_rs_content.contains("impl ProviderService for AwsProvider"));
     assert!(lib_rs_content.contains("fn schema(&self)"));
+    assert!(lib_rs_content.contains("PROTOCOL_VERSION"));
+    assert!(lib_rs_content.contains("SDK_PROTOCOL_VERSION"));
 
     // Clean up
     fs::remove_dir_all(&output_dir).expect("Failed to clean up test directory");


### PR DESCRIPTION
## Summary

Updates generated providers to use `hemmer-provider-sdk` 0.2 which includes protocol version negotiation for provider compatibility.

## Changes

- **Cargo.toml templates**: Require SDK 0.2+ (comment notes it's required for protocol versioning)
- **lib.rs templates**: Import and re-export protocol version constants:
  - `PROTOCOL_VERSION` - current protocol version
  - `MIN_PROTOCOL_VERSION` - minimum compatible version
  - `check_protocol_version()` - validation function
  - `SDK_PROTOCOL_VERSION` / `SDK_MIN_PROTOCOL_VERSION` - re-exports for consumers
- **Tests**: Verify SDK 0.2 dependency and protocol version exports

## How It Works

The SDK handles version negotiation automatically via the `serve()` function handshake:
1. Provider starts and outputs `HEMMER_PROVIDER|<version>|<address>` to stdout
2. Hemmer connects and sends its protocol version in `GetSchema` request
3. SDK validates compatibility using `check_protocol_version()`
4. Returns error if versions are incompatible

## Test Plan

- [x] All 68 workspace tests pass
- [x] Clippy clean
- [x] Tests verify SDK 0.2 dependency in generated Cargo.toml
- [x] Tests verify protocol version imports in generated lib.rs

## Related

- Closes #78
- Depends on: hemmer-io/hemmer-provider-sdk#29 (completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)