### PR TITLE
ci: add success summary jobs to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,42 @@ jobs:
         run: cargo doc --workspace --all-features --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
+
+  # Summary job that fails if any required job fails
+  # This provides a single check for branch protection
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [format, clippy, test, docs, audit]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          echo "Format: ${{ needs.format.result }}"
+          echo "Clippy: ${{ needs.clippy.result }}"
+          echo "Test: ${{ needs.test.result }}"
+          echo "Docs: ${{ needs.docs.result }}"
+          echo "Audit: ${{ needs.audit.result }}"
+
+          if [[ "${{ needs.format.result }}" != "success" ]]; then
+            echo "::error::Format check failed"
+            exit 1
+          fi
+          if [[ "${{ needs.clippy.result }}" != "success" ]]; then
+            echo "::error::Clippy check failed"
+            exit 1
+          fi
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "::error::Tests failed"
+            exit 1
+          fi
+          if [[ "${{ needs.docs.result }}" != "success" ]]; then
+            echo "::error::Documentation check failed"
+            exit 1
+          fi
+          if [[ "${{ needs.audit.result }}" != "success" ]]; then
+            echo "::error::Security audit failed"
+            exit 1
+          fi
+
+          echo "::notice::All CI checks passed successfully!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,3 +115,26 @@ jobs:
           cd ../generator && cargo publish --allow-dirty
           sleep 30
           cd ../cli && cargo publish --allow-dirty
+
+  # Summary job that confirms all release steps completed
+  release-success:
+    name: Release Success
+    runs-on: ubuntu-latest
+    needs: [build, publish]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          echo "Build: ${{ needs.build.result }}"
+          echo "Publish: ${{ needs.publish.result }}"
+
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "::error::Build failed"
+            exit 1
+          fi
+          if [[ "${{ needs.publish.result }}" != "success" ]]; then
+            echo "::error::Publish failed"
+            exit 1
+          fi
+
+          echo "::notice::Release completed successfully!"


### PR DESCRIPTION
## Summary
- Add `ci-success` job to CI workflow that aggregates results from all 5 CI jobs (format, clippy, test, docs, audit)
- Add `release-success` job to release workflow that confirms both build and publish completed successfully
- Both summary jobs use `if: always()` to run regardless of previous job failures
- Provide clear error messages using GitHub Actions annotations to identify which checks failed

## Benefits
- Enables single status check for branch protection (instead of needing to require all 5+ individual jobs)
- Makes it immediately clear which CI step failed when looking at the PR
- Consistent pattern for both CI and release workflows

## Test plan
- [ ] Verify CI workflow runs and ci-success job reports correctly when all jobs pass
- [ ] Verify ci-success job fails with appropriate error when any upstream job fails
- [ ] Verify release workflow structure is correct (manual testing on next release)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)